### PR TITLE
[Hotfix/113] :hammer: BookmarkService -> delete 함수 수정

### DIFF
--- a/src/main/java/com/vincent/domain/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/com/vincent/domain/bookmark/repository/BookmarkRepository.java
@@ -17,4 +17,6 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
 
     Page<Bookmark> findAllByMemberOrderByCreatedAtDesc(Member member, PageRequest pageRequest);
 
+    Bookmark findByMemberAndSocket(Member member, Socket socket);
+
 }

--- a/src/main/java/com/vincent/domain/bookmark/service/BookmarkService.java
+++ b/src/main/java/com/vincent/domain/bookmark/service/BookmarkService.java
@@ -86,7 +86,8 @@ public class BookmarkService {
 
 
     public void delete(Member member, Socket socket) {
-        bookmarkRepository.delete(Bookmark.builder().member(member).socket(socket).build());
+        Bookmark bookmark = bookmarkRepository.findByMemberAndSocket(member, socket);
+        bookmarkRepository.delete(bookmark);
     }
 
 

--- a/src/test/java/com/vincent/domain/bookmark/service/BookmarkServiceTest.java
+++ b/src/test/java/com/vincent/domain/bookmark/service/BookmarkServiceTest.java
@@ -135,13 +135,20 @@ public class BookmarkServiceTest {
     @Test
     public void 북마크취소_성공() {
 
+
+        Bookmark bookmark = Bookmark.builder()
+            .member(member)
+            .socket(socket)
+            .build();
+
         when(memberRepository.findById(memberId)).thenReturn(java.util.Optional.of(member));
         when(socketRepository.findById(socketId)).thenReturn(java.util.Optional.of(socket));
         when(bookmarkRepository.existsBySocketAndMember(socket, member)).thenReturn(true);
+        when(bookmarkRepository.findByMemberAndSocket(member, socket)).thenReturn(bookmark);
 
         bookmarkService.deleteBookmark(socketId, memberId);
 
-        verify(bookmarkRepository, times(1)).delete(any(Bookmark.class));
+        verify(bookmarkRepository, times(1)).delete(bookmark);
     }
 
     @Test

--- a/src/test/java/com/vincent/domain/building/service/BuildingServiceTest.java
+++ b/src/test/java/com/vincent/domain/building/service/BuildingServiceTest.java
@@ -341,16 +341,13 @@ public class BuildingServiceTest {
         double xCoordinate = 10;
         double yCoordinate = 20;
         String name = "Space";
-        String uploadUrl = "https://s3.amazonaws.com/example.jpg";
         boolean isSocketExist = true;
 
         when(floorRepository.findById(floorId)).thenReturn(Optional.of(floor));
-        when(s3Service.upload(image, name)).thenReturn(uploadUrl);
 
         buildingService.createSpace(floorId, xCoordinate, yCoordinate, name, isSocketExist);
 
         verify(spaceRepository).save(any(Space.class));
-        verify(s3Service).upload(image, "Space");
     }
 
     @Test


### PR DESCRIPTION
## #️⃣연관된 이슈
> #113

## 📝작업 내용
> 기존의 바로 delete함수에서 bookmark엔티티를 빌더패턴으로 생성해서 제거하는 방식에서, BookmarkRepository에 findByMemberAndSocket을 추가하여 bookmark객체를 생성한 후 해당 객체를 delete 함수에 적용하는 방식으로 바꾸었습니다
