### PR TITLE
[Fix/115] :hammer: 피드백 생성 시 생성시간 설정, request 중복 제거

### DIFF
--- a/src/main/java/com/vincent/domain/feedback/controller/FeedbackController.java
+++ b/src/main/java/com/vincent/domain/feedback/controller/FeedbackController.java
@@ -24,7 +24,6 @@ public class FeedbackController {
     private final FeedbackService feedbackService;
 
     @Operation(summary = "피드백 생성하기")
-    @Parameter(name = "contents", description = "내용은 최대 300자까지 가능")
     @PostMapping("/feedback")
     public ApiResponse<?> addFeedback(@RequestBody @Valid FeedbackRequestDto.addFeedbackDto request,
         Authentication authentication) {

--- a/src/main/java/com/vincent/domain/feedback/entity/Feedback.java
+++ b/src/main/java/com/vincent/domain/feedback/entity/Feedback.java
@@ -3,6 +3,7 @@ package com.vincent.domain.feedback.entity;
 import com.vincent.domain.member.entity.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -16,12 +17,14 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
 public class Feedback {
 
     @Id


### PR DESCRIPTION
## #️⃣연관된 이슈
> #115 

## 📝작업 내용
> Feedback 엔티티 : @EntityListeners(AuditingEntityListener.class) 추가 -> createdAt 생성되도록 수정
> FeedbackController : @Parameter(name = "contents", description = "내용은 최대 300자까지 가능")제거 -> request 중복 제거
