### PR TITLE
[Fix/113] :hammer: 북마크 취소 api 수정

### DIFF
--- a/src/main/java/com/vincent/apipayload/status/ErrorStatus.java
+++ b/src/main/java/com/vincent/apipayload/status/ErrorStatus.java
@@ -31,6 +31,7 @@ public enum ErrorStatus implements BaseCode {
     // 북마크
     BOOKMARK_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "BOOKMARK4001", "이미 북마크에 추가된 콘센트입니다."),
     BOOKMARK_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "BOOKMARK4002", "이미 북마크에서 삭제된 콘센트입니다."),
+    BOOKMARK_NOT_FOUND(HttpStatus.NOT_FOUND, "BOOKMARK4003", "북마크를 찾을 수 없습니다."),
 
     // 멤버
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER4001", "회원 정보를 찾을 수 없습니다."),

--- a/src/main/java/com/vincent/domain/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/com/vincent/domain/bookmark/repository/BookmarkRepository.java
@@ -17,4 +17,6 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
 
     Page<Bookmark> findAllByMemberOrderByCreatedAtDesc(Member member, PageRequest pageRequest);
 
+    Bookmark findByMemberAndSocket(Member member, Socket socket);
+
 }

--- a/src/main/java/com/vincent/domain/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/com/vincent/domain/bookmark/repository/BookmarkRepository.java
@@ -4,6 +4,7 @@ import com.vincent.domain.bookmark.entity.Bookmark;
 import com.vincent.domain.member.entity.Member;
 import com.vincent.domain.socket.entity.Socket;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -17,6 +18,6 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
 
     Page<Bookmark> findAllByMemberOrderByCreatedAtDesc(Member member, PageRequest pageRequest);
 
-    Bookmark findByMemberAndSocket(Member member, Socket socket);
+    Optional<Bookmark> findByMemberAndSocket(Member member, Socket socket);
 
 }

--- a/src/main/java/com/vincent/domain/bookmark/service/BookmarkService.java
+++ b/src/main/java/com/vincent/domain/bookmark/service/BookmarkService.java
@@ -35,7 +35,8 @@ public class BookmarkService {
         Member member = memberDataService.findById(memberId);
         Socket socket = socketDataService.findById(socketId);
         bookmarkDataService.isBookmarkDeleted(socket, member);
-        bookmarkDataService.delete(Bookmark.builder().member(member).socket(socket).build());
+        Bookmark bookmark = bookmarkDataService.findByMemberAndSocket(member, socket);
+        bookmarkDataService.delete(bookmark);
     }
 
     public Page<Bookmark> findBookmarkList(Long memberId, Integer page) {

--- a/src/main/java/com/vincent/domain/bookmark/service/data/BookmarkDataService.java
+++ b/src/main/java/com/vincent/domain/bookmark/service/data/BookmarkDataService.java
@@ -47,15 +47,8 @@ public class BookmarkDataService {
 
     public Bookmark findByMemberAndSocket(Member member, Socket socket) {
 
-        Optional<Bookmark> bookmark = bookmarkRepository.findByMemberAndSocket(member, socket);
-
-        if (bookmark.isPresent()) {
-            Bookmark foundBookmark = bookmark.get();
-            return  foundBookmark;
-
-        } else {
-            throw new ErrorHandler(ErrorStatus.BOOKMARK_NOT_FOUND);
-        }
+        return bookmarkRepository.findByMemberAndSocket(member, socket).orElseThrow(
+            () -> new ErrorHandler(ErrorStatus.BOOKMARK_NOT_FOUND));
     }
 
     public Page<Bookmark> findAllByMember(Member member, Integer page) {

--- a/src/main/java/com/vincent/domain/bookmark/service/data/BookmarkDataService.java
+++ b/src/main/java/com/vincent/domain/bookmark/service/data/BookmarkDataService.java
@@ -44,6 +44,10 @@ public class BookmarkDataService {
 
     }
 
+    public Bookmark findByMemberAndSocket(Member member, Socket socket) {
+        return bookmarkRepository.findByMemberAndSocket(member, socket);
+    }
+
     public Page<Bookmark> findAllByMember(Member member, Integer page) {
         return bookmarkRepository.findAllByMemberOrderByCreatedAtDesc(member,
             PageRequest.of(page, 10));

--- a/src/main/java/com/vincent/domain/bookmark/service/data/BookmarkDataService.java
+++ b/src/main/java/com/vincent/domain/bookmark/service/data/BookmarkDataService.java
@@ -54,7 +54,7 @@ public class BookmarkDataService {
             return  foundBookmark;
 
         } else {
-            throw new ErrorHandler(ErrorStatus.BOOKMARK_ALREADY_DELETED);
+            throw new ErrorHandler(ErrorStatus.BOOKMARK_NOT_FOUND);
         }
     }
 

--- a/src/main/java/com/vincent/domain/bookmark/service/data/BookmarkDataService.java
+++ b/src/main/java/com/vincent/domain/bookmark/service/data/BookmarkDataService.java
@@ -6,6 +6,7 @@ import com.vincent.domain.bookmark.repository.BookmarkRepository;
 import com.vincent.domain.member.entity.Member;
 import com.vincent.domain.socket.entity.Socket;
 import com.vincent.exception.handler.ErrorHandler;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -45,7 +46,16 @@ public class BookmarkDataService {
     }
 
     public Bookmark findByMemberAndSocket(Member member, Socket socket) {
-        return bookmarkRepository.findByMemberAndSocket(member, socket);
+
+        Optional<Bookmark> bookmark = bookmarkRepository.findByMemberAndSocket(member, socket);
+
+        if (bookmark.isPresent()) {
+            Bookmark foundBookmark = bookmark.get();
+            return  foundBookmark;
+
+        } else {
+            throw new ErrorHandler(ErrorStatus.BOOKMARK_ALREADY_DELETED);
+        }
     }
 
     public Page<Bookmark> findAllByMember(Member member, Integer page) {

--- a/src/test/java/com/vincent/domain/bookmark/service/BookmarkServiceTest.java
+++ b/src/test/java/com/vincent/domain/bookmark/service/BookmarkServiceTest.java
@@ -68,10 +68,16 @@ public class BookmarkServiceTest {
         Member member = Member.builder().id(1L).build();
         Socket socket = Socket.builder().id(1L).build();
 
+        Bookmark bookmark = Bookmark.builder()
+            .member(member)
+            .socket(socket)
+            .build();
+
         //when
         when(memberDataService.findById(memberId)).thenReturn(member);
         when(socketDataService.findById(socketId)).thenReturn(socket);
         doNothing().when(bookmarkDataService).isBookmarkDeleted(socket,member);
+        when(bookmarkDataService.findByMemberAndSocket(member, socket)).thenReturn(bookmark);
         doNothing().when(bookmarkDataService).delete(any(Bookmark.class));
 
         //then
@@ -81,6 +87,7 @@ public class BookmarkServiceTest {
         verify(memberDataService, times(1)).findById(memberId);
         verify(socketDataService, times(1)).findById(socketId);
         verify(bookmarkDataService, times(1)).isBookmarkDeleted(socket, member);
+        verify(bookmarkDataService, times(1)).findByMemberAndSocket(member, socket);
 
     }
 

--- a/src/test/java/com/vincent/domain/bookmark/service/data/BookmarkDataServiceTest.java
+++ b/src/test/java/com/vincent/domain/bookmark/service/data/BookmarkDataServiceTest.java
@@ -12,6 +12,7 @@ import com.vincent.domain.member.entity.Member;
 import com.vincent.domain.socket.entity.Socket;
 import com.vincent.exception.handler.ErrorHandler;
 import java.util.Arrays;
+import java.util.Optional;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -130,6 +131,41 @@ class BookmarkDataServiceTest {
         // then
         bookmarkDataService.isBookmarkDeleted(socket, member);
         verify(bookmarkRepository, times(1)).existsBySocketAndMember(socket, member);
+    }
+
+    @Test
+    void findByMemberAndSocket_성공() {
+        // given
+        Member member = Member.builder().id(1L).build();
+        Socket socket = Socket.builder().id(1L).build();
+        Bookmark bookmark = Bookmark.builder().member(member).socket(socket).build();
+
+        // when
+        when(bookmarkRepository.findByMemberAndSocket(member, socket)).thenReturn(Optional.of(bookmark));
+
+        // then
+        Bookmark result = bookmarkDataService.findByMemberAndSocket(member, socket);
+
+        Assertions.assertEquals(bookmark, result);
+        verify(bookmarkRepository, times(1)).findByMemberAndSocket(member, socket);
+    }
+
+    @Test
+    void findByMemberAndSocket_실패_해당북마크없음() {
+        // given
+        Member member = Member.builder().id(1L).build();
+        Socket socket = Socket.builder().id(1L).build();
+
+        // when
+        when(bookmarkRepository.findByMemberAndSocket(member, socket)).thenReturn(Optional.empty());
+
+        // then
+        ErrorHandler thrown = Assertions.assertThrows(ErrorHandler.class,
+            () ->  bookmarkDataService.findByMemberAndSocket(member, socket));
+
+
+        Assertions.assertEquals(thrown.getCode(), ErrorStatus.BOOKMARK_ALREADY_DELETED);
+        verify(bookmarkRepository, times(1)).findByMemberAndSocket(member, socket);
     }
 
     @Test

--- a/src/test/java/com/vincent/domain/bookmark/service/data/BookmarkDataServiceTest.java
+++ b/src/test/java/com/vincent/domain/bookmark/service/data/BookmarkDataServiceTest.java
@@ -164,7 +164,7 @@ class BookmarkDataServiceTest {
             () ->  bookmarkDataService.findByMemberAndSocket(member, socket));
 
 
-        Assertions.assertEquals(thrown.getCode(), ErrorStatus.BOOKMARK_ALREADY_DELETED);
+        Assertions.assertEquals(thrown.getCode(), ErrorStatus.BOOKMARK_NOT_FOUND);
         verify(bookmarkRepository, times(1)).findByMemberAndSocket(member, socket);
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈
> #113 

## 📝작업 내용
> 기존의 delete함수에서 bookmark엔티티를 바로 빌더패턴으로 생성해서 제거하는 방식에서, BookmarkRepository에 findByMemberAndSocket을 추가하여 bookmark객체를 생성한 후 해당 객체를 delete 함수에 적용하는 방식으로 바꾸었습니다
