### PR TITLE
:hammer: 빌딩 검색 api 수정

### DIFF
--- a/src/main/java/com/vincent/domain/building/controller/BuildingController.java
+++ b/src/main/java/com/vincent/domain/building/controller/BuildingController.java
@@ -46,7 +46,7 @@ public class BuildingController {
     @Parameter(name = "page", description = "검색 목록의 페이지 번호(0부터 시작)")
     @GetMapping("/building/search")
     public ApiResponse<BuildingResponseDto.BuildingList> buildingList(
-        @RequestParam("keyword") String keyword,
+        @RequestParam(value = "keyword") String keyword,
         @RequestParam("page") Integer page) {
         Page<Building> buildingPage = buildingService.getBuildingSearch(keyword, page);
         return ApiResponse.onSuccess(BuildingConverter.toBuildingListResponse(buildingPage));

--- a/src/main/java/com/vincent/domain/building/repository/custombuilding/CustomBuildingRepositoryImpl.java
+++ b/src/main/java/com/vincent/domain/building/repository/custombuilding/CustomBuildingRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.vincent.domain.building.repository.custombuilding;
 import com.vincent.domain.building.entity.Building;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
+import java.util.Collections;
 import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -16,6 +17,10 @@ public class CustomBuildingRepositoryImpl implements CustomBuildingRepository {
 
     @Override
     public Page<Building> findByNameContainingOrderBySimilarity(String keyword, PageRequest pageRequest) {
+
+        if (keyword == null || keyword.trim().isEmpty()) {
+            return new PageImpl<>(Collections.emptyList(), pageRequest, 0);
+        }
 
         String jpql = "SELECT b FROM Building b WHERE b.name LIKE CONCAT('%', :keyword, '%') "
             + "ORDER BY CASE "


### PR DESCRIPTION
## #️⃣연관된 이슈
> #130

## 📝작업 내용
1. 빌딩을 조회하면 keyword에 빈 문자열이 들어가면서 모든 건물을 조회하게 되는 오류가 있었습니다.
``` Java
        String jpql = "SELECT b FROM Building b WHERE b.name LIKE CONCAT('%', :keyword, '%') "
            + "ORDER BY CASE "
            + "WHEN b.name = :keyword THEN 0 "
            + "WHEN b.name LIKE CONCAT(:keyword, '%') THEN 1 "
            + "WHEN b.name LIKE CONCAT('%', :keyword, '%') THEN 2 "
            + "WHEN b.name LIKE CONCAT('%', :keyword) THEN 3 "
            + "ELSE 4 END";
```

그래서 빈 문자열이 들어오면 검색을 하지 않도록 하는 로직을 추가했습니다.

```
        if (keyword == null || keyword.trim().isEmpty()) {
            return new PageImpl<>(Collections.emptyList(), pageRequest, 0);
        }
```
