### PR TITLE
[Fix/123] 건물 정보 조회api 수정

### DIFF
--- a/src/main/java/com/vincent/domain/building/controller/BuildingController.java
+++ b/src/main/java/com/vincent/domain/building/controller/BuildingController.java
@@ -2,10 +2,12 @@ package com.vincent.domain.building.controller;
 
 import com.vincent.apipayload.ApiResponse;
 import com.vincent.domain.building.controller.dto.BuildingResponseDto;
+import com.vincent.domain.building.controller.dto.BuildingResponseDto.FloorWithSocket;
 import com.vincent.domain.building.converter.BuildingConverter;
 import com.vincent.domain.building.entity.Building;
 import com.vincent.domain.building.controller.dto.BuildingResponseDto.FloorInfoProjection;
 import com.vincent.domain.building.controller.dto.BuildingResponseDto.SpaceInfoProjection;
+import com.vincent.domain.building.entity.Floor;
 import com.vincent.domain.building.service.BuildingService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -97,9 +99,11 @@ public class BuildingController {
         @RequestParam("buildingId") Long buildingId,
         @RequestParam("level") Integer level) {
         FloorInfoProjection floorInfoProjection = buildingService.getFloorInfo(buildingId, level);
+        List<FloorWithSocket> floorWithSocketList = buildingService.getFloorList(buildingId);
         List<SpaceInfoProjection> spaceInfoProjectionList = buildingService.getSpaceInfoList(buildingId, level);
         return  ApiResponse.onSuccess((
-            BuildingConverter.toFloorInfoListResponse(floorInfoProjection, spaceInfoProjectionList)));
+            BuildingConverter.toFloorInfoListResponse(
+                floorInfoProjection, floorWithSocketList, spaceInfoProjectionList)));
 
 
     }

--- a/src/main/java/com/vincent/domain/building/controller/BuildingController.java
+++ b/src/main/java/com/vincent/domain/building/controller/BuildingController.java
@@ -37,10 +37,11 @@ public class BuildingController {
     @Operation(summary = "건물의 정보 조회하기", description = "지도 상에서 건물 마크를 클릭했을 때 보여지는 정보를 제공함")
     @Parameter(name = "buildingId", description = "정보를 조회할 빌딩의 Id")
     @GetMapping("/building/{buildingId}")
-    public ApiResponse<BuildingResponseDto.BuildingInfo> buildingInfo(
+    public ApiResponse<BuildingResponseDto.BuildingAndFloorInfo> buildingInfo(
         @PathVariable("buildingId") Long buildingId) {
         Building result = buildingService.getBuildingInfo(buildingId);
-        return ApiResponse.onSuccess(BuildingConverter.toBuildingInfoResponse(result));
+        List<FloorWithSocket> floorWithSocketList = buildingService.getFloorWithSocketList(buildingId);
+        return ApiResponse.onSuccess(BuildingConverter.toBuildingAndFloorInfoResponse(result, floorWithSocketList));
     }
 
     @Operation(summary = "검색하기", description = "검색창에 입력한 키워드와 건물의 이름이 일치하는 순서대로 건물 목록을 조회함(한 페이지에 최대 10개씩)")
@@ -99,11 +100,9 @@ public class BuildingController {
         @RequestParam("buildingId") Long buildingId,
         @RequestParam("level") Integer level) {
         FloorInfoProjection floorInfoProjection = buildingService.getFloorInfo(buildingId, level);
-        List<FloorWithSocket> floorWithSocketList = buildingService.getFloorList(buildingId);
         List<SpaceInfoProjection> spaceInfoProjectionList = buildingService.getSpaceInfoList(buildingId, level);
         return  ApiResponse.onSuccess((
-            BuildingConverter.toFloorInfoListResponse(
-                floorInfoProjection, floorWithSocketList, spaceInfoProjectionList)));
+            BuildingConverter.toFloorInfoListResponse(floorInfoProjection, spaceInfoProjectionList)));
 
 
     }

--- a/src/main/java/com/vincent/domain/building/controller/dto/BuildingResponseDto.java
+++ b/src/main/java/com/vincent/domain/building/controller/dto/BuildingResponseDto.java
@@ -72,6 +72,7 @@ public class BuildingResponseDto {
         Integer currentFloor;
         String floorImage;
         List<SpaceInfoProjection> spaceInfoList;
+        List<FloorWithSocket> floorWithSocketList;
 
 
 
@@ -111,6 +112,35 @@ public class BuildingResponseDto {
         private Boolean socketExistence;
 
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class FloorWithSocket {
+
+        private Long floorId;
+        private Integer floorLevel;
+
+    }
+
+    /*
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class FloorInfoProjection2 {
+
+
+        private String buildingName;
+        private Long floors;
+        private Integer currentFloor;
+        private String floorImage;
+        List<A> aa;
+
+    }
+
+     */
 
 
 }

--- a/src/main/java/com/vincent/domain/building/controller/dto/BuildingResponseDto.java
+++ b/src/main/java/com/vincent/domain/building/controller/dto/BuildingResponseDto.java
@@ -27,6 +27,19 @@ public class BuildingResponseDto {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    public static class BuildingAndFloorInfo {
+
+        Long buildingId;
+        String buildingName;
+        String buildingImage;
+        String buildingAddress;
+        List<FloorWithSocket> floorWithSocketList;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class BuildingList {
 
         List<BuildingInfo> buildingInfos;
@@ -72,7 +85,6 @@ public class BuildingResponseDto {
         Integer currentFloor;
         String floorImage;
         List<SpaceInfoProjection> spaceInfoList;
-        List<FloorWithSocket> floorWithSocketList;
 
 
 

--- a/src/main/java/com/vincent/domain/building/converter/BuildingConverter.java
+++ b/src/main/java/com/vincent/domain/building/converter/BuildingConverter.java
@@ -6,6 +6,7 @@ import com.vincent.domain.bookmark.converter.BookmarkConverter;
 import com.vincent.domain.building.controller.dto.BuildingRequestDto;
 import com.vincent.domain.building.controller.dto.BuildingResponseDto;
 import com.vincent.domain.building.controller.dto.BuildingResponseDto.BuildingInfo;
+import com.vincent.domain.building.controller.dto.BuildingResponseDto.FloorWithSocket;
 import com.vincent.domain.building.entity.Building;
 import com.vincent.domain.building.entity.Floor;
 import com.vincent.domain.building.entity.Space;
@@ -53,12 +54,14 @@ public class BuildingConverter {
     }
 
     public static BuildingResponseDto.FloorInfo toFloorInfoListResponse(
-        FloorInfoProjection a, List<SpaceInfoProjection> b) {
+        FloorInfoProjection a, List<FloorWithSocket> c, List<SpaceInfoProjection> b) {
+
         return BuildingResponseDto.FloorInfo.builder()
             .buildingName(a.getBuildingName())
             .floors(a.getFloors())
             .currentFloor(a.getCurrentFloor())
             .floorImage(a.getFloorImage())
+            .floorWithSocketList(c)
             .spaceInfoList(b).build();
 
     }

--- a/src/main/java/com/vincent/domain/building/converter/BuildingConverter.java
+++ b/src/main/java/com/vincent/domain/building/converter/BuildingConverter.java
@@ -19,7 +19,19 @@ import org.springframework.data.domain.Page;
 
 public class BuildingConverter {
 
-    public static BuildingResponseDto.BuildingInfo toBuildingInfoResponse(Building result) {
+    public static BuildingResponseDto.BuildingAndFloorInfo toBuildingAndFloorInfoResponse(
+        Building result, List<FloorWithSocket> floorWithSocketList) {
+        return BuildingResponseDto.BuildingAndFloorInfo.builder()
+            .buildingId(result.getId())
+            .buildingName(result.getName())
+            .buildingImage(result.getImage())
+            .buildingAddress(result.getAddress())
+            .floorWithSocketList(floorWithSocketList)
+            .build();
+    }
+
+    public static BuildingResponseDto.BuildingInfo toBuildingInfoResponse(
+        Building result) {
         return BuildingResponseDto.BuildingInfo.builder()
             .buildingId(result.getId())
             .buildingName(result.getName())
@@ -54,14 +66,13 @@ public class BuildingConverter {
     }
 
     public static BuildingResponseDto.FloorInfo toFloorInfoListResponse(
-        FloorInfoProjection a, List<FloorWithSocket> c, List<SpaceInfoProjection> b) {
+        FloorInfoProjection a, List<SpaceInfoProjection> b) {
 
         return BuildingResponseDto.FloorInfo.builder()
             .buildingName(a.getBuildingName())
             .floors(a.getFloors())
             .currentFloor(a.getCurrentFloor())
             .floorImage(a.getFloorImage())
-            .floorWithSocketList(c)
             .spaceInfoList(b).build();
 
     }

--- a/src/main/java/com/vincent/domain/building/repository/FloorRepository.java
+++ b/src/main/java/com/vincent/domain/building/repository/FloorRepository.java
@@ -3,6 +3,7 @@ package com.vincent.domain.building.repository;
 import com.vincent.domain.building.entity.Building;
 import com.vincent.domain.building.entity.Floor;
 import com.vincent.domain.building.repository.customfloor.CustomFloorRepository;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -10,6 +11,8 @@ public interface FloorRepository extends JpaRepository<Floor, Long>, CustomFloor
 
 
     Optional<Floor> findByBuildingAndLevel(Building building, Integer level);
+
+    //List<Floor> findAllByBuildingId(Long buildingId);
 
 
 

--- a/src/main/java/com/vincent/domain/building/repository/customfloor/CustomFloorRepository.java
+++ b/src/main/java/com/vincent/domain/building/repository/customfloor/CustomFloorRepository.java
@@ -1,9 +1,13 @@
 package com.vincent.domain.building.repository.customfloor;
 
 import com.vincent.domain.building.controller.dto.BuildingResponseDto.FloorInfoProjection;
+import com.vincent.domain.building.controller.dto.BuildingResponseDto.FloorWithSocket;
+import java.util.List;
 
 public interface CustomFloorRepository {
 
     FloorInfoProjection findFloorInfoByBuildingIdAndLevel(Long buildingId, int level);
+
+    List<FloorWithSocket>  findFloorWithSocketByBuildingId(Long buildingId);
 
 }

--- a/src/main/java/com/vincent/domain/building/repository/customfloor/CustomFloorRepository.java
+++ b/src/main/java/com/vincent/domain/building/repository/customfloor/CustomFloorRepository.java
@@ -8,6 +8,6 @@ public interface CustomFloorRepository {
 
     FloorInfoProjection findFloorInfoByBuildingIdAndLevel(Long buildingId, int level);
 
-    List<FloorWithSocket>  findFloorWithSocketByBuildingId(Long buildingId);
+    List<FloorWithSocket>  findFloorWithSocketListByBuildingId(Long buildingId);
 
 }

--- a/src/main/java/com/vincent/domain/building/repository/customfloor/CustomFloorRepositoryImpl.java
+++ b/src/main/java/com/vincent/domain/building/repository/customfloor/CustomFloorRepositoryImpl.java
@@ -32,7 +32,7 @@ public class CustomFloorRepositoryImpl implements CustomFloorRepository {
     }
 
     @Override
-    public List<FloorWithSocket> findFloorWithSocketByBuildingId(Long buildingId) {
+    public List<FloorWithSocket> findFloorWithSocketListByBuildingId(Long buildingId) {
 
         String jpql = "SELECT new com.vincent.domain.building.controller.dto.BuildingResponseDto$FloorWithSocket("
             + "f.id, "

--- a/src/main/java/com/vincent/domain/building/repository/customfloor/CustomFloorRepositoryImpl.java
+++ b/src/main/java/com/vincent/domain/building/repository/customfloor/CustomFloorRepositoryImpl.java
@@ -1,8 +1,10 @@
 package com.vincent.domain.building.repository.customfloor;
 
 import com.vincent.domain.building.controller.dto.BuildingResponseDto.FloorInfoProjection;
+import com.vincent.domain.building.controller.dto.BuildingResponseDto.FloorWithSocket;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
+import java.util.List;
 import org.springframework.transaction.annotation.Transactional;
 
 public class CustomFloorRepositoryImpl implements CustomFloorRepository {
@@ -27,6 +29,22 @@ public class CustomFloorRepositoryImpl implements CustomFloorRepository {
             .setParameter("buildingId", buildingId)
             .setParameter("level", level)
             .getSingleResult();
+    }
+
+    @Override
+    public List<FloorWithSocket> findFloorWithSocketByBuildingId(Long buildingId) {
+
+        String jpql = "SELECT new com.vincent.domain.building.controller.dto.BuildingResponseDto$FloorWithSocket("
+            + "f.id, "
+            + "f.level) "
+            + "FROM Floor f "
+            + "WHERE f.building.id = :buildingId "
+            + "ORDER BY f.level ASC";
+
+        // JPQL Query 실행
+        return entityManager.createQuery(jpql, FloorWithSocket.class)
+            .setParameter("buildingId", buildingId)
+            .getResultList();
     }
 
 }

--- a/src/main/java/com/vincent/domain/building/service/BuildingService.java
+++ b/src/main/java/com/vincent/domain/building/service/BuildingService.java
@@ -1,6 +1,7 @@
 package com.vincent.domain.building.service;
 
 import com.vincent.config.aws.s3.S3Service;
+import com.vincent.domain.building.controller.dto.BuildingResponseDto.FloorWithSocket;
 import com.vincent.domain.building.entity.Building;
 import com.vincent.domain.building.entity.Floor;
 import com.vincent.domain.building.entity.Space;
@@ -76,6 +77,11 @@ public class BuildingService {
     public FloorInfoProjection getFloorInfo(Long buildingId, int level) {
         return floorDataService.findFloorInfoByBuildingIdAndLevel(buildingId, level);
     }
+
+    public List<FloorWithSocket> getFloorList(Long buildingId) {
+        return floorDataService.findFloorListByBuildingId(buildingId);
+    }
+
 
     public List<SpaceInfoProjection> getSpaceInfoList(Long buildingId, int level) {
         return spaceDataService.getSpaceInfoList(buildingId, level);

--- a/src/main/java/com/vincent/domain/building/service/BuildingService.java
+++ b/src/main/java/com/vincent/domain/building/service/BuildingService.java
@@ -78,8 +78,8 @@ public class BuildingService {
         return floorDataService.findFloorInfoByBuildingIdAndLevel(buildingId, level);
     }
 
-    public List<FloorWithSocket> getFloorList(Long buildingId) {
-        return floorDataService.findFloorListByBuildingId(buildingId);
+    public List<FloorWithSocket> getFloorWithSocketList(Long buildingId) {
+        return floorDataService.findFloorWithSocketListByBuildingId(buildingId);
     }
 
 

--- a/src/main/java/com/vincent/domain/building/service/data/FloorDataService.java
+++ b/src/main/java/com/vincent/domain/building/service/data/FloorDataService.java
@@ -30,8 +30,8 @@ public class FloorDataService {
         return floorRepository.findFloorInfoByBuildingIdAndLevel(buildingId, level);
     }
 
-    public List<FloorWithSocket> findFloorListByBuildingId(Long buildingId) {
-        return floorRepository.findFloorWithSocketByBuildingId(buildingId);
+    public List<FloorWithSocket> findFloorWithSocketListByBuildingId(Long buildingId) {
+        return floorRepository.findFloorWithSocketListByBuildingId(buildingId);
     }
 
     public Floor findByBuildingAndLevel(Building building, Integer level) {

--- a/src/main/java/com/vincent/domain/building/service/data/FloorDataService.java
+++ b/src/main/java/com/vincent/domain/building/service/data/FloorDataService.java
@@ -2,10 +2,12 @@ package com.vincent.domain.building.service.data;
 
 import com.vincent.apipayload.status.ErrorStatus;
 import com.vincent.domain.building.controller.dto.BuildingResponseDto.FloorInfoProjection;
+import com.vincent.domain.building.controller.dto.BuildingResponseDto.FloorWithSocket;
 import com.vincent.domain.building.entity.Building;
 import com.vincent.domain.building.entity.Floor;
 import com.vincent.domain.building.repository.FloorRepository;
 import com.vincent.exception.handler.ErrorHandler;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -26,6 +28,10 @@ public class FloorDataService {
 
     public FloorInfoProjection findFloorInfoByBuildingIdAndLevel(Long buildingId, int level) {
         return floorRepository.findFloorInfoByBuildingIdAndLevel(buildingId, level);
+    }
+
+    public List<FloorWithSocket> findFloorListByBuildingId(Long buildingId) {
+        return floorRepository.findFloorWithSocketByBuildingId(buildingId);
     }
 
     public Floor findByBuildingAndLevel(Building building, Integer level) {

--- a/src/test/java/com/vincent/domain/building/controller/BuildingControllerTest.java
+++ b/src/test/java/com/vincent/domain/building/controller/BuildingControllerTest.java
@@ -12,9 +12,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.vincent.apipayload.ApiResponse;
 import com.vincent.domain.building.controller.dto.BuildingResponseDto;
+import com.vincent.domain.building.controller.dto.BuildingResponseDto.BuildingAndFloorInfo;
 import com.vincent.domain.building.controller.dto.BuildingResponseDto.BuildingInfo;
 import com.vincent.domain.building.controller.dto.BuildingResponseDto.BuildingLocationList;
 import com.vincent.domain.building.controller.dto.BuildingResponseDto.FloorInfoProjection;
+import com.vincent.domain.building.controller.dto.BuildingResponseDto.FloorWithSocket;
 import com.vincent.domain.building.controller.dto.BuildingResponseDto.SpaceInfoProjection;
 import com.vincent.domain.building.converter.BuildingConverter;
 import com.vincent.domain.building.entity.Building;
@@ -47,6 +49,9 @@ public class BuildingControllerTest {
     private Floor floor;
     private Space space;
     private FloorInfoProjection floorInfoProjection;
+
+    @Mock
+    private FloorWithSocket floorWithSocket;
 
     private SpaceInfoProjection spaceInfoProjection;
 
@@ -97,14 +102,15 @@ public class BuildingControllerTest {
         //given
         Long buildingId = 1L;
 
+        List<FloorWithSocket> floorWithSocketList = List.of(floorWithSocket);
         //when
         when(buildingService.getBuildingInfo(eq(buildingId))).thenReturn(building);
 
         //then
-        ApiResponse<BuildingResponseDto.BuildingInfo> response = buildingController.buildingInfo(
+        ApiResponse<BuildingResponseDto.BuildingAndFloorInfo> response = buildingController.buildingInfo(
             buildingId);
-        BuildingResponseDto.BuildingInfo result = response.getResult();
-        BuildingInfo expected = BuildingConverter.toBuildingInfoResponse(building);
+        BuildingResponseDto.BuildingAndFloorInfo result = response.getResult();
+        BuildingAndFloorInfo expected = BuildingConverter.toBuildingAndFloorInfoResponse(building, floorWithSocketList);
 
         Assertions.assertThat(response).isNotNull();
         Assertions.assertThat(response.getCode()).isEqualTo("COMMON200");

--- a/src/test/java/com/vincent/domain/building/service/BuildingServiceTest.java
+++ b/src/test/java/com/vincent/domain/building/service/BuildingServiceTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.when;
 
 import com.vincent.config.aws.s3.S3Service;
 import com.vincent.domain.building.controller.dto.BuildingResponseDto.FloorInfoProjection;
+import com.vincent.domain.building.controller.dto.BuildingResponseDto.FloorWithSocket;
 import com.vincent.domain.building.controller.dto.BuildingResponseDto.SpaceInfoProjection;
 import com.vincent.domain.building.entity.Building;
 import com.vincent.domain.building.entity.Floor;
@@ -127,6 +128,23 @@ public class BuildingServiceTest {
 
         assertEquals(building, result);
         verify(buildingDataService, times(1)).findById(buildingId);
+
+
+    }
+
+    @Test
+    public void 건물정보조회_getFloorWithSocketList_성공() {
+        // given
+        Long buildingId = 1L;
+        List<FloorWithSocket> expectedFloorWithSocketList = List.of(new FloorWithSocket());
+        // Mock 객체 반환값 설정
+        when(floorDataService.findFloorWithSocketListByBuildingId(buildingId)).thenReturn(expectedFloorWithSocketList);
+        // when
+        List<FloorWithSocket> result = buildingService.getFloorWithSocketList(buildingId);
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result).isEqualTo(expectedFloorWithSocketList);
+        verify(floorDataService, times(1)).findFloorWithSocketListByBuildingId(buildingId); // 메서드 호출 확인
     }
 
 

--- a/src/test/java/com/vincent/domain/building/service/data/FloorDataServiceTest.java
+++ b/src/test/java/com/vincent/domain/building/service/data/FloorDataServiceTest.java
@@ -1,15 +1,18 @@
 package com.vincent.domain.building.service.data;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.vincent.apipayload.status.ErrorStatus;
 import com.vincent.domain.building.controller.dto.BuildingResponseDto.FloorInfoProjection;
+import com.vincent.domain.building.controller.dto.BuildingResponseDto.FloorWithSocket;
 import com.vincent.domain.building.entity.Building;
 import com.vincent.domain.building.entity.Floor;
 import com.vincent.domain.building.repository.FloorRepository;
 import com.vincent.exception.handler.ErrorHandler;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -120,6 +123,21 @@ class FloorDataServiceTest {
         ErrorHandler thrown = Assertions.assertThrows(ErrorHandler.class,
             () -> floorDataService.findByBuildingAndLevel(building, level));
         Assertions.assertEquals(ErrorStatus.FLOOR_NOT_FOUND, thrown.getCode());
+    }
+
+    @Test
+    public void 건물로_소켓이_있는_층_찾기_성공() {
+        // given
+        Long buildingId = 1L;
+        List<FloorWithSocket> expectedFloorWithSocketList = List.of(new FloorWithSocket());
+        // Mock 객체 반환값 설정
+        when(floorRepository.findFloorWithSocketListByBuildingId(buildingId)).thenReturn(expectedFloorWithSocketList);
+        // when
+        List<FloorWithSocket> result = floorDataService.findFloorWithSocketListByBuildingId(buildingId);
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result).isEqualTo(expectedFloorWithSocketList);
+        verify(floorRepository, times(1)).findFloorWithSocketListByBuildingId(buildingId); // 메서드 호출 확인
     }
 }
 

--- a/src/test/java/com/vincent/domain/building/service/data/FloorDataServiceTest.java
+++ b/src/test/java/com/vincent/domain/building/service/data/FloorDataServiceTest.java
@@ -139,5 +139,22 @@ class FloorDataServiceTest {
         assertThat(result).isEqualTo(expectedFloorWithSocketList);
         verify(floorRepository, times(1)).findFloorWithSocketListByBuildingId(buildingId); // 메서드 호출 확인
     }
+
+    @Test
+    public void 건물로_소켓이_있는_층_찾기_실패() {
+        // given
+        Long buildingId = 1L;
+        List<FloorWithSocket> emptyFloorWithSocketList = List.of(); // 빈 리스트
+
+        // 빈 리스트 반환 모킹
+        when(floorRepository.findFloorWithSocketListByBuildingId(buildingId)).thenReturn(emptyFloorWithSocketList);
+
+        // when
+        List<FloorWithSocket> result = floorDataService.findFloorWithSocketListByBuildingId(buildingId);
+
+        // then
+        assertThat(result).isNotNull();
+        verify(floorRepository, times(1)).findFloorWithSocketListByBuildingId(buildingId); // 메서드 호출 확인
+    }
 }
 


### PR DESCRIPTION
## #️⃣연관된 이슈
> #123 

## 📝작업 내용
1. 건물 정보 조회api에 소켓이 있는 층들의 리스트 필드 추가
2. 층 조회 api에 해당 필드 잘못 추가한 후 수정하여 건물 정보 조회 api로 제대로 추가 하였음