### PR TITLE
[Fix/140] :hammer: 층 조회 responseDto -> jsonProperty 추가

### DIFF
--- a/src/main/java/com/vincent/domain/building/controller/dto/BuildingResponseDto.java
+++ b/src/main/java/com/vincent/domain/building/controller/dto/BuildingResponseDto.java
@@ -1,5 +1,6 @@
 package com.vincent.domain.building.controller.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.util.ArrayList;
 import java.util.List;
@@ -115,9 +116,17 @@ public class BuildingResponseDto {
     @AllArgsConstructor
     public static class SpaceInfoProjection {
 
+
+        @JsonProperty("spaceName")
         private String spaceName;
+
+        @JsonProperty("xcoordinate")
         private Double xCoordinate;
+
+        @JsonProperty("ycoordinate")
         private Double yCoordinate;
+
+        @JsonProperty("socketExistence")
         private Boolean socketExistence;
 
     }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #140 

## 📝작업 내용
>  층 조회 api 호출 시 xCoordinate, yCoordinate이 모두 소문자로 출력되서 혼동을 일으킴 -> ResponseDto의 해당 필드에 jsonProperty를 추가하였음
