### PR TITLE
[Fix/142] :hammer: 층 콘센트 조회 @jsonProperty 추가, @jsonPropertyOrder로 순서 고정

### DIFF
--- a/src/main/java/com/vincent/domain/building/controller/dto/BuildingResponseDto.java
+++ b/src/main/java/com/vincent/domain/building/controller/dto/BuildingResponseDto.java
@@ -114,6 +114,7 @@ public class BuildingResponseDto {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    @JsonPropertyOrder({"spaceName", "socketExistence", "xCoordinate", "yCoordinate"})
     public static class SpaceInfoProjection {
 
 

--- a/src/main/java/com/vincent/domain/socket/controller/dto/SocketResponseDto.java
+++ b/src/main/java/com/vincent/domain/socket/controller/dto/SocketResponseDto.java
@@ -1,5 +1,7 @@
 package com.vincent.domain.socket.controller.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -27,10 +29,15 @@ public class SocketResponseDto {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    @JsonPropertyOrder({"socketId", "xCoordinate", "yCoordinate"})
     public static class SocketLocation {
 
         Long socketId;
+
+        @JsonProperty("xcoordinate")
         Double xCoordinate;
+
+        @JsonProperty("ycoordinate")
         Double yCoordinate;
 
     }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #142 

## 📝작업 내용
> 층 콘센트 조회 시  @jsonProperty를 이용하여 x축 y축을 소문자로 설정하였고, 층 조회 api와 층 콘센트 조회 api의 응답값이 해당 어노테이션을 사용한 후 필드 순서가 달라져서 @JsonPropertyOrder를 이용해 순서를 고정함
