### PR TITLE
Spring Security 개선

### DIFF
--- a/src/main/java/com/vincent/apipayload/ApiResponse.java
+++ b/src/main/java/com/vincent/apipayload/ApiResponse.java
@@ -3,6 +3,7 @@ package com.vincent.apipayload;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.vincent.apipayload.status.ErrorStatus;
 import com.vincent.apipayload.status.SuccessStatus;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -26,5 +27,9 @@ public class ApiResponse<T> {
 
     public static <T> ApiResponse<T> onFailure(String code, String message, T data) {
         return new ApiResponse<>(false, code, message, data);
+    }
+
+    public static <T> ApiResponse<T> onFailure(ErrorStatus errorStatus) {
+        return new ApiResponse<>(false, errorStatus.getCode(), errorStatus.getMessage(), null);
     }
 }

--- a/src/main/java/com/vincent/config/redis/service/RedisService.java
+++ b/src/main/java/com/vincent/config/redis/service/RedisService.java
@@ -41,7 +41,7 @@ public class RedisService {
      * 리프레시 토큰 재발급
      */
     public RefreshToken regenerateRefreshToken(Member member, RefreshToken refreshToken) {
-        refreshTokenRepository.delete(refreshToken);
+        this.delete(refreshToken);
         String newRefreshToken = jwtProvider.createRefreshToken(member.getId(), member.getEmail());
         return refreshTokenRepository.save(
             RefreshToken.builder()

--- a/src/main/java/com/vincent/config/security/SecurityConfig.java
+++ b/src/main/java/com/vincent/config/security/SecurityConfig.java
@@ -75,7 +75,7 @@ public class SecurityConfig {
                 .anyRequest().authenticated())
             .addFilterBefore(new JwtFilter(jwtProvider),
                 UsernamePasswordAuthenticationFilter.class)
-            .addFilterBefore(new BlackListFilter(redisService, jwtProvider),
+            .addFilterAt(new BlackListFilter(redisService, jwtProvider),
                 UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }

--- a/src/main/java/com/vincent/config/security/filter/BlackListFilter.java
+++ b/src/main/java/com/vincent/config/security/filter/BlackListFilter.java
@@ -22,7 +22,6 @@ public class BlackListFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
             FilterChain filterChain) throws ServletException, IOException {
-
         String accessToken = jwtProvider.resolveToken(request);
         if (accessToken == null) {
             filterChain.doFilter(request, response);
@@ -31,10 +30,7 @@ public class BlackListFilter extends OncePerRequestFilter {
         if (redisService.isBlacklisted(accessToken)) {
             response.setContentType("application/json");
             ApiResponse<Object> baseResponseDto = ApiResponse.onFailure(
-                    ErrorStatus.JWT_TOKEN_LOGOUT.getCode(),
-                    ErrorStatus.JWT_TOKEN_LOGOUT.getMessage(),
-                    null
-            );
+                ErrorStatus.JWT_TOKEN_LOGOUT);
             ObjectMapper objectMapper = new ObjectMapper();
             objectMapper.writeValue(response.getOutputStream(), baseResponseDto);
             return;

--- a/src/main/java/com/vincent/config/security/handler/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/vincent/config/security/handler/JwtAccessDeniedHandler.java
@@ -19,12 +19,9 @@ public class JwtAccessDeniedHandler implements AccessDeniedHandler {
     @Override
     public void handle(HttpServletRequest request, HttpServletResponse response,
             AccessDeniedException accessDeniedException) throws IOException, ServletException {
-        log.error("JwtAccessDeniedHandler 실행");
+        log.error("JwtAccessDeniedHandler 실행", accessDeniedException.getMessage());
         response.setContentType("application/json");
-        ApiResponse<Object> baseResponseDto = ApiResponse.onFailure(
-                ErrorStatus._UNAUTHORIZED.getCode(),
-                ErrorStatus._UNAUTHORIZED.getMessage(),
-                null);
+        ApiResponse<Object> baseResponseDto = ApiResponse.onFailure(ErrorStatus._UNAUTHORIZED);
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.writeValue(response.getOutputStream(), baseResponseDto);
     }

--- a/src/main/java/com/vincent/config/security/handler/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/vincent/config/security/handler/JwtAuthenticationEntryPoint.java
@@ -19,15 +19,10 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response,
-            AuthenticationException authException) throws IOException, ServletException {
-        log.error("JwtAuthenticationEntryPoint 실행: {}", authException.getMessage(), authException);
+        AuthenticationException authException) throws IOException, ServletException {
+        log.error("JwtAuthenticationEntryPoint 실행: {}", authException.getMessage());
         response.setContentType("application/json");
-
-        ApiResponse<Object> baseResponseDto =
-                ApiResponse.onFailure(
-                        ErrorStatus.JWT_TOKEN_NOT_FOUND.getCode(),
-                        ErrorStatus.JWT_TOKEN_NOT_FOUND.getMessage(),
-                        null);
+        ApiResponse<Object> baseResponseDto = ApiResponse.onFailure(ErrorStatus.JWT_TOKEN_NOT_FOUND);
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.writeValue(response.getOutputStream(), baseResponseDto);
     }

--- a/src/main/java/com/vincent/config/security/provider/JwtProvider.java
+++ b/src/main/java/com/vincent/config/security/provider/JwtProvider.java
@@ -24,7 +24,7 @@ public class JwtProvider implements InitializingBean {
     @Value("${jwt.token.secret}")
     private String secret;
     private static SecretKey secretKey;
-    private static final Long expireAccessMs = 1000L * 60 * 60; //30분
+    private static final Long expireAccessMs = 1000L * 60 * 15; //15분
 
     private static final Long expireRefreshMs = 1000L * 60 * 60 * 24 * 7;  //7일
 
@@ -48,6 +48,11 @@ public class JwtProvider implements InitializingBean {
     public String getRole(String token) {
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload()
             .get("role", String.class);
+    }
+
+    public String getSocialType(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload()
+            .get("socialType", String.class);
     }
 
     public Boolean isExpired(String token) {

--- a/src/main/java/com/vincent/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/vincent/config/swagger/SwaggerConfig.java
@@ -17,7 +17,7 @@ public class SwaggerConfig {
         Info info = new Info()
                 .title("Vincent")
                 .description("Vincent API 명세서")
-                .version("v1.0.2");
+                .version("v1.0.4");
 
         String jwtSchemeName = "JWT TOKEN";
         SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);

--- a/src/main/java/com/vincent/domain/member/entity/enums/SocialType.java
+++ b/src/main/java/com/vincent/domain/member/entity/enums/SocialType.java
@@ -1,5 +1,16 @@
 package com.vincent.domain.member.entity.enums;
 
-public enum SocialType{
-    KAKAO, APPLE
+import com.vincent.apipayload.status.ErrorStatus;
+import com.vincent.exception.handler.ErrorHandler;
+
+public enum SocialType {
+    KAKAO, APPLE;
+
+    public static SocialType fromString(String socialType) {
+        try {
+            return SocialType.valueOf(socialType.toUpperCase()); // 문자열을 대문자로 변환 후 매칭
+        } catch (Exception e) {
+            throw new ErrorHandler(ErrorStatus._INTERNAL_SERVER_ERROR);
+        }
+    }
 }

--- a/src/main/java/com/vincent/domain/member/service/MemberService.java
+++ b/src/main/java/com/vincent/domain/member/service/MemberService.java
@@ -54,7 +54,7 @@ public class MemberService {
 
         Member member = memberDataService.findById(refreshToken.getMemberId());
 
-        String newAccessToken = jwtProvider.createAccessToken(member.getId(), member.getEmail());
+        String newAccessToken = jwtProvider.createAccessToken(member.getId(), member.getEmail(), member.getSocialType());
         String newRefreshToken = redisService.regenerateRefreshToken(member, refreshToken)
                 .getRefreshToken();
 

--- a/src/test/java/com/vincent/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/vincent/domain/member/service/MemberServiceTest.java
@@ -15,6 +15,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.Optional;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
@@ -50,8 +51,10 @@ class MemberServiceTest {
             .build();
 
         //when
-        when(memberDataService.findByEmailAndSocialType(email, SocialType.KAKAO)).thenReturn(Optional.of(member));
-        when(jwtProvider.createAccessToken(member.getId(), member.getEmail(), member.getSocialType())).thenReturn(accessToken);
+        when(memberDataService.findByEmailAndSocialType(email, SocialType.KAKAO)).thenReturn(
+            Optional.of(member));
+        when(jwtProvider.createAccessToken(member.getId(), member.getEmail(),
+            member.getSocialType())).thenReturn(accessToken);
         when(redisService.generateRefreshToken(member)).thenReturn(refreshToken);
         LoginResult result = memberService.login(email, SocialType.KAKAO);
 
@@ -65,7 +68,7 @@ class MemberServiceTest {
     }
 
     @Test
-    public void 로그인성공_회원가입(){
+    public void 로그인성공_회원가입() {
         //given
         Member member = Member.builder()
             .id(1L)
@@ -80,9 +83,11 @@ class MemberServiceTest {
             .build();
 
         //when
-        when(memberDataService.findByEmailAndSocialType(email, SocialType.KAKAO)).thenReturn(Optional.empty());
+        when(memberDataService.findByEmailAndSocialType(email, SocialType.KAKAO)).thenReturn(
+            Optional.empty());
         when(memberDataService.save(any(Member.class))).thenReturn(member);
-        when(jwtProvider.createAccessToken(member.getId(), member.getEmail(), member.getSocialType())).thenReturn(accessToken);
+        when(jwtProvider.createAccessToken(member.getId(), member.getEmail(),
+            member.getSocialType())).thenReturn(accessToken);
         when(redisService.generateRefreshToken(member)).thenReturn(refreshToken);
         LoginResult result = memberService.login(email, SocialType.KAKAO);
 
@@ -103,6 +108,7 @@ class MemberServiceTest {
         Member member = Member.builder()
             .id(1L)
             .email("test@gmail.com")
+            .socialType(SocialType.KAKAO)
             .build();
         RefreshToken refreshToken = RefreshToken.builder()
             .memberId(member.getId())
@@ -113,19 +119,20 @@ class MemberServiceTest {
             .refreshToken("refresh2")
             .build();
 
-
         //when
         doNothing().when(jwtProvider).validateToken(token);
         when(jwtProvider.getMemberId(token)).thenReturn(1L);
         when(redisService.findByMemberId(1L)).thenReturn(refreshToken);
         when(memberDataService.findById(1L)).thenReturn(member);
-        when(jwtProvider.createAccessToken(member.getId(), member.getEmail())).thenReturn("token2");
-        when(redisService.regenerateRefreshToken(member,refreshToken)).thenReturn(refreshToken2);
+        when(jwtProvider.createAccessToken(member.getId(), member.getEmail(),
+            member.getSocialType())).thenReturn("token2");
+        when(redisService.regenerateRefreshToken(member, refreshToken)).thenReturn(refreshToken2);
         ReissueResult result = memberService.reissue(token);
 
         //then
-        verify(jwtProvider,times(1)).getMemberId(token);
-        verify(jwtProvider, times(1)).createAccessToken(member.getId(), member.getEmail());
+        verify(jwtProvider, times(1)).getMemberId(token);
+        verify(jwtProvider, times(1)).createAccessToken(member.getId(), member.getEmail(),
+            member.getSocialType());
         verify(redisService, times(1)).regenerateRefreshToken(member, refreshToken);
         Assertions.assertEquals(result.getAccessToken(), newToken);
         Assertions.assertEquals(result.getRefreshToken(), refreshToken2.getRefreshToken());
@@ -148,7 +155,7 @@ class MemberServiceTest {
         //then
         verify(jwtProvider, times(1)).getMemberId(refreshToken);
         verify(redisService, times(1)).exists(memberId);
-        verify(redisService,times(1)).delete(memberId);
+        verify(redisService, times(1)).delete(memberId);
         verify(redisService, times(1)).blacklist(accessToken);
     }
 
@@ -172,7 +179,7 @@ class MemberServiceTest {
     }
 
     @Test
-    public void 회원탈퇴(){
+    public void 회원탈퇴() {
         //given
         Long memberId = 1L;
         Member member = Member.builder()
@@ -189,7 +196,6 @@ class MemberServiceTest {
         Assertions.assertEquals(member.isWithdraw(), true);
 
     }
-
 
 //
 //    @Test


### PR DESCRIPTION
## #️⃣연관된 이슈
> #164

## 📝작업 내용
1. 토큰을 재발급 할 때 헤더에 만료된 토큰이 있으면 오류가 발생했습니다. 때문에 JwtFilter에서 한번도 URI를 확인하는 절차를 추가했습니다. 이제 토큰을 재발급 할 때 만료된 토큰을 헤더에 넣어도 오류가 발생하지 않습니다.
2. 기존 JwtFilter는 하나의 메서드로만 이루어져 있었습니다. 하나의 메서드에 모든 로직이 작성되어 있어 가독성이 떨어졌습니다. 이를 해결하기 위해 메서드를 잘게 분리시켰습니다.
3. 기존 ErrorHandler는 아래 코드처럼 작성했습니다.
```  Java
ApiResponse<Object> baseResponseDto = ApiResponse.onFailure(
                    ErrorStatus.JWT_TOKEN_LOGOUT.getCode(),
                    ErrorStatus.JWT_TOKEN_LOGOUT.getMessage(),
                    null
            );
```
불필요하게 코드가 길어져서 가독성이 떨어진다고 판단하여 아래와 같이 개선했습니다.
``` Java
ApiResponse<Object> baseResponseDto = ApiResponse.onFailure(
                ErrorStatus.JWT_TOKEN_LOGOUT);
```
