### PR TITLE
🔨 Fix/170 소켓 장소 조회 api

### DIFF
--- a/src/main/java/com/vincent/domain/socket/controller/SocketController.java
+++ b/src/main/java/com/vincent/domain/socket/controller/SocketController.java
@@ -53,4 +53,14 @@ public class SocketController {
 
     }
 
+    @Operation(summary = "콘센트 존재 장소 조회하기", description = "콘센트Id로 콘센트가 존재하는 건물의 Id와 층을 조회함")
+    @GetMapping("/socket/place")
+    public ApiResponse<SocketResponseDto.SocketPlace> getSocketPlace(
+        @RequestParam("socketId") Long socketId) {
+        return ApiResponse.onSuccess((
+            SocketConverter.toSocketPlace(socketService.getSocketPlace(socketId))));
+
+
+    }
+
 }

--- a/src/main/java/com/vincent/domain/socket/controller/dto/SocketResponseDto.java
+++ b/src/main/java/com/vincent/domain/socket/controller/dto/SocketResponseDto.java
@@ -52,4 +52,14 @@ public class SocketResponseDto {
 
     }
 
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SocketPlace {
+
+        Long buildingId;
+        Integer level;
+    }
+
 }

--- a/src/main/java/com/vincent/domain/socket/converter/SocketConverter.java
+++ b/src/main/java/com/vincent/domain/socket/converter/SocketConverter.java
@@ -1,5 +1,7 @@
 package com.vincent.domain.socket.converter;
 
+import com.vincent.domain.building.entity.Floor;
+import com.vincent.domain.building.entity.Space;
 import com.vincent.domain.socket.controller.dto.SocketResponseDto;
 import com.vincent.domain.socket.entity.Socket;
 import java.util.List;
@@ -31,6 +33,13 @@ public class SocketConverter {
             .map(SocketConverter::toSocketLocation).collect(Collectors.toList());
         return SocketResponseDto.SocketLocationList.builder()
             .locationList(socketLocationList)
+            .build();
+    }
+
+    public static SocketResponseDto.SocketPlace toSocketPlace(SocketResponseDto.SocketPlace socketPlace) {
+        return SocketResponseDto.SocketPlace.builder()
+            .buildingId(socketPlace.getBuildingId())
+            .level(socketPlace.getLevel())
             .build();
     }
 

--- a/src/main/java/com/vincent/domain/socket/repository/SocketRepository.java
+++ b/src/main/java/com/vincent/domain/socket/repository/SocketRepository.java
@@ -3,11 +3,12 @@ package com.vincent.domain.socket.repository;
 import com.vincent.domain.bookmark.entity.Bookmark;
 import com.vincent.domain.building.entity.Space;
 import com.vincent.domain.socket.entity.Socket;
+import com.vincent.domain.socket.repository.customsocket.CustomSocketRepository;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface SocketRepository extends JpaRepository<Socket, Long> {
+public interface SocketRepository extends JpaRepository<Socket, Long>, CustomSocketRepository {
 
     List<Socket> findAllBySpace(Space space);
 

--- a/src/main/java/com/vincent/domain/socket/repository/customsocket/CustomSocketRepository.java
+++ b/src/main/java/com/vincent/domain/socket/repository/customsocket/CustomSocketRepository.java
@@ -1,0 +1,9 @@
+package com.vincent.domain.socket.repository.customsocket;
+
+import com.vincent.domain.socket.controller.dto.SocketResponseDto.SocketPlace;
+
+public interface CustomSocketRepository {
+
+    SocketPlace findSocketPlaceBySocketId(Long socketId);
+
+}

--- a/src/main/java/com/vincent/domain/socket/repository/customsocket/CustomSocketRepositoryImpl.java
+++ b/src/main/java/com/vincent/domain/socket/repository/customsocket/CustomSocketRepositoryImpl.java
@@ -1,0 +1,34 @@
+package com.vincent.domain.socket.repository.customsocket;
+
+import com.vincent.domain.building.controller.dto.BuildingResponseDto.SpaceInfoProjection;
+import com.vincent.domain.building.repository.customspace.CustomSpaceRepository;
+import com.vincent.domain.socket.controller.dto.SocketResponseDto.SocketPlace;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.util.List;
+
+public class CustomSocketRepositoryImpl implements CustomSocketRepository {
+
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Override
+    public SocketPlace findSocketPlaceBySocketId(Long socketId) {
+
+        String jpql = "SELECT new com.vincent.domain.socket.controller.dto.SocketResponseDto$SocketPlace("
+            + "building.id, "
+            + "floor.level ) "
+            + "FROM Socket socket "
+            + "JOIN socket.space space "
+            + "JOIN space.floor floor "
+            + "JOIN floor.building building "
+            + "WHERE socket.id = :socketId";
+
+        return entityManager.createQuery(jpql, SocketPlace.class)
+            .setParameter("socketId", socketId)
+            .getSingleResult();
+    }
+
+
+}

--- a/src/main/java/com/vincent/domain/socket/service/SocketService.java
+++ b/src/main/java/com/vincent/domain/socket/service/SocketService.java
@@ -6,6 +6,7 @@ import com.vincent.domain.building.entity.Space;
 import com.vincent.domain.building.service.data.BuildingDataService;
 import com.vincent.domain.building.service.data.FloorDataService;
 import com.vincent.domain.building.service.data.SpaceDataService;
+import com.vincent.domain.socket.controller.dto.SocketResponseDto;
 import com.vincent.domain.socket.entity.Socket;
 import com.vincent.domain.socket.service.data.SocketDataService;
 import java.util.List;
@@ -39,6 +40,11 @@ public class SocketService {
             .flatMap(sockets -> sockets.stream())
             .collect(Collectors.toList());
 
+    }
+
+    public SocketResponseDto.SocketPlace getSocketPlace(Long socketId) {
+
+        return socketDataService.findSocketPlaceBySocketId(socketId);
     }
 
 }

--- a/src/main/java/com/vincent/domain/socket/service/data/SocketDataService.java
+++ b/src/main/java/com/vincent/domain/socket/service/data/SocketDataService.java
@@ -30,7 +30,9 @@ public class SocketDataService {
     }
 
     public SocketResponseDto.SocketPlace findSocketPlaceBySocketId(Long socketId) {
-        return socketRepository.findSocketPlaceBySocketId(socketId);
+        return socketRepository.findById(socketId)
+            .map(socket -> socketRepository.findSocketPlaceBySocketId(socketId))
+            .orElseThrow(() -> new ErrorHandler(ErrorStatus.SOCKET_NOT_FOUND));
     }
 
 }

--- a/src/main/java/com/vincent/domain/socket/service/data/SocketDataService.java
+++ b/src/main/java/com/vincent/domain/socket/service/data/SocketDataService.java
@@ -2,6 +2,7 @@ package com.vincent.domain.socket.service.data;
 
 import com.vincent.apipayload.status.ErrorStatus;
 import com.vincent.domain.building.entity.Space;
+import com.vincent.domain.socket.controller.dto.SocketResponseDto;
 import com.vincent.domain.socket.entity.Socket;
 import com.vincent.domain.socket.repository.SocketRepository;
 import com.vincent.exception.handler.ErrorHandler;
@@ -26,6 +27,10 @@ public class SocketDataService {
 
     public Socket save(Socket socket) {
         return socketRepository.save(socket);
+    }
+
+    public SocketResponseDto.SocketPlace findSocketPlaceBySocketId(Long socketId) {
+        return socketRepository.findSocketPlaceBySocketId(socketId);
     }
 
 }

--- a/src/test/java/com/vincent/domain/socket/controller/SocketControllerTest.java
+++ b/src/test/java/com/vincent/domain/socket/controller/SocketControllerTest.java
@@ -5,12 +5,17 @@ import static org.mockito.Mockito.when;
 import com.vincent.apipayload.ApiResponse;
 import com.vincent.config.security.principal.PrincipalDetails;
 import com.vincent.domain.bookmark.service.BookmarkService;
+import com.vincent.domain.building.controller.dto.BuildingResponseDto;
+import com.vincent.domain.building.controller.dto.BuildingResponseDto.SpaceInfoProjection;
+import com.vincent.domain.building.converter.BuildingConverter;
 import com.vincent.domain.building.entity.Building;
 import com.vincent.domain.building.entity.Floor;
 import com.vincent.domain.building.entity.Space;
 import com.vincent.domain.member.entity.Member;
 import com.vincent.domain.socket.controller.dto.SocketResponseDto;
 import com.vincent.domain.socket.controller.dto.SocketResponseDto.SocketInfo;
+import com.vincent.domain.socket.controller.dto.SocketResponseDto.SocketPlace;
+import com.vincent.domain.socket.converter.SocketConverter;
 import com.vincent.domain.socket.entity.Socket;
 import com.vincent.domain.socket.service.SocketService;
 import java.util.List;
@@ -41,6 +46,9 @@ public class SocketControllerTest {
     private PrincipalDetails principalDetails;
 
     private Socket socket;
+
+    private SocketPlace socketPlace;
+
     @BeforeEach
     public void setUp() {
         Member member = Member.builder().id(1L).build();
@@ -49,6 +57,7 @@ public class SocketControllerTest {
         Floor floor = Floor.builder().id(1L).building(building).build();
         Space space = Space.builder().id(1L).floor(floor).name("floor1").build();
         socket = Socket.builder().id(1L).space(space).build();
+        socketPlace = SocketPlace.builder().buildingId(1L).level(1).build();
     }
 
     @Test
@@ -86,4 +95,28 @@ public class SocketControllerTest {
         Assertions.assertThat(response.getMessage()).isEqualTo("성공입니다");
         Assertions.assertThat(response.getResult().getLocationList().size()).isEqualTo(1);
     }
+
+    @Test
+    public void 소켓장소조회_성공() {
+
+        //given
+        Long socketId = 1L;
+
+        //when
+        when(socketService.getSocketPlace(socketId)).thenReturn(socketPlace);
+
+        //then
+        ApiResponse<SocketResponseDto.SocketPlace> response = socketController.getSocketPlace(socketId);
+        SocketResponseDto.SocketPlace result = response.getResult();
+        SocketResponseDto.SocketPlace expected = SocketConverter.toSocketPlace(
+            socketPlace);
+
+        Assertions.assertThat(response).isNotNull();
+        Assertions.assertThat(response.getCode()).isEqualTo("COMMON200");
+        Assertions.assertThat(response.getMessage()).isEqualTo("성공입니다");
+        Assertions.assertThat(result.getBuildingId()).isEqualTo(expected.getBuildingId());
+        Assertions.assertThat(result.getLevel()).isEqualTo(expected.getLevel());
+
+    }
+
 }

--- a/src/test/java/com/vincent/domain/socket/service/SocketServiceTest.java
+++ b/src/test/java/com/vincent/domain/socket/service/SocketServiceTest.java
@@ -9,6 +9,8 @@ import com.vincent.domain.building.entity.Space;
 import com.vincent.domain.building.service.data.BuildingDataService;
 import com.vincent.domain.building.service.data.FloorDataService;
 import com.vincent.domain.building.service.data.SpaceDataService;
+import com.vincent.domain.socket.controller.dto.SocketResponseDto;
+import com.vincent.domain.socket.controller.dto.SocketResponseDto.SocketPlace;
 import com.vincent.domain.socket.entity.Socket;
 import com.vincent.domain.socket.service.data.SocketDataService;
 import java.util.Collections;
@@ -85,5 +87,24 @@ public class SocketServiceTest {
         verify(floorDataService).findByBuildingAndLevel(building, level);
         verify(spaceDataService).findAllByFloor(floor);
         verify(socketDataService).findAllBySpace(space);
+    }
+
+    @Test
+    void 소켓장소조회_성공() {
+
+        //given
+        Long socketId = 1L;
+        SocketResponseDto.SocketPlace socketPlace;
+        socketPlace = SocketPlace.builder().buildingId(1L).level(1).build();
+
+        //when
+        when(socketDataService.findSocketPlaceBySocketId(socketId)).thenReturn(socketPlace);
+
+        //then
+        SocketPlace result = socketService.getSocketPlace(socketId);
+
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(socketPlace, result);
+        verify(socketDataService).findSocketPlaceBySocketId(socketId);
     }
 }

--- a/src/test/java/com/vincent/domain/socket/service/data/SocketDataServiceTest.java
+++ b/src/test/java/com/vincent/domain/socket/service/data/SocketDataServiceTest.java
@@ -1,10 +1,13 @@
 package com.vincent.domain.socket.service.data;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.vincent.apipayload.status.ErrorStatus;
 import com.vincent.domain.building.entity.Space;
+import com.vincent.domain.socket.controller.dto.SocketResponseDto;
+import com.vincent.domain.socket.controller.dto.SocketResponseDto.SocketPlace;
 import com.vincent.domain.socket.entity.Socket;
 import com.vincent.domain.socket.repository.SocketRepository;
 import com.vincent.exception.handler.ErrorHandler;
@@ -73,6 +76,7 @@ class SocketDataServiceTest {
         verify(socketRepository, times(1)).findAllBySpace(space);
     }
 
+
     @Test
     void 저장() {
         //given
@@ -85,6 +89,53 @@ class SocketDataServiceTest {
         Socket result = socketDataService.save(socket);
         Assertions.assertNotNull(result);
         verify(socketRepository).save(socket);
+    }
+
+    @Test
+    void 소켓아이디로_빌딩아이디와_층_찾기_성공() {
+        //given
+        Long socketId = 1L;
+        Socket socket = Socket.builder().id(1L).build();
+        SocketResponseDto.SocketPlace socketPlace;
+        socketPlace = SocketPlace.builder().buildingId(1L).level(1).build();
+
+        //when
+        when(socketRepository.findById(socketId)).thenReturn(Optional.of(socket));
+        when(socketRepository.findSocketPlaceBySocketId(socketId)).thenReturn(socketPlace);
+
+        //then
+        SocketPlace result = socketDataService.findSocketPlaceBySocketId(socketId);
+        Assertions.assertEquals(result.getBuildingId(), socketPlace.getBuildingId());
+        Assertions.assertEquals(result.getLevel(), socketPlace.getLevel());
+
+        //verify
+        verify(socketRepository, times(1)).findById(socketId);
+        verify(socketRepository, times(1)).findSocketPlaceBySocketId(socketId);
+
+
+
+    }
+
+    @Test
+    void 소켓아이디로_빌딩아이디와_층_찾기_실패() {
+
+        // given
+        Long invalidSocketId = 9L;
+
+        //when
+        when(socketRepository.findById(invalidSocketId)).thenReturn(Optional.empty());
+
+        //then
+        ErrorHandler thrown = Assertions.assertThrows(ErrorHandler.class,
+            () -> socketDataService.findById(invalidSocketId));
+        Assertions.assertEquals(thrown.getCode(), ErrorStatus.SOCKET_NOT_FOUND);
+
+        //verify
+        verify(socketRepository, times(1)).findById(invalidSocketId);
+        verify(socketRepository, never()).findSocketPlaceBySocketId(invalidSocketId);
+
+
+
     }
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #170 

## 📝작업 내용
## 기존 방식 
 소켓 조회 api의 responseDto에 buildingId와 level필드를 추가

### 문제점
 페이징된 북마크 리스트에서, 북마크된 소켓의 id를 이용하여 해당 소켓과 연결된 floor, building엔티티의 필드를 쿼리로 가져와서 다시 ResponseDto에 넣는 과정이 복잡했음

## 해결 방식 
소켓의 id를 RequestParam으로 받으면 빌딩id와 level을 리턴하는 새로운 api를 만듦

### 해결 과정
socketDataservice : 인자로 받은 소켓id로 먼저 소켓의 존재 여부를 확인하고 소켓이 있으면 
socket, space, floor, building 엔티티를 삼중 join 하여 두 필드를 리턴하는 쿼리에 id를 넘겼고 소켓이 없으면 에러메시지를 출력하도록 했음

### 발생한 에러
1. customSocketRepositoryImpl : jpql문 중 
![image](https://github.com/user-attachments/assets/9494596e-2372-45cb-887b-e033b7a20fb6)
이 부분에서 '(' expected, got '.' 오류 발생

inner 클래스를 new 키워드와 함께 JPQL에서 사용할 때 나타나는 문제이며 SocketResponseDto.SocketPlace를 별도의 public 클래스로 정의하거나, 내부 클래스의 정적(static) 선언을 확인해 보아야 한다는데 이미 static 선언이 되어있음
그리고 빨간 줄을 무시하고 실행해도 api가 작동이 잘 되기에 무시했음

