### PR TITLE
:hammer: 로깅 수정

### DIFF
--- a/src/main/java/com/vincent/logs/LogService.java
+++ b/src/main/java/com/vincent/logs/LogService.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.LoggerFactory;
@@ -53,18 +54,11 @@ public class LogService {
         List<ApiLogs> apiLogs = apiLogsRepository.findByCreatedAtBetween(
             startOfYesterday, endOfYesterday);
 
-        Pattern pattern = Pattern.compile("memberId=(\\d+)");
-        Set<Long> uniqueMemberIds = new HashSet<>();
+        Set<String> uniqueMemberIds = apiLogs.stream()
+            .map(ApiLogs::getMemberId)   // memberId 필드만 추출
+            .filter(memberId -> memberId != null && !memberId.isEmpty()) // null 또는 빈 값 필터링
+            .collect(Collectors.toSet()); // 중복 제거
 
-        // 각 로그에서 memberId 추출 및 집합에 추가
-        apiLogs.stream().forEach(log -> {
-            String message = log.getMessage();
-            Matcher matcher = pattern.matcher(message);
-            if (matcher.find()) {
-                Long memberId = Long.parseLong(matcher.group(1));
-                uniqueMemberIds.add(memberId);
-            }
-        });
 
         DailyActiveUsers dailyActiveUsers = DailyActiveUsers.builder()
             .date(LocalDate.now().minusDays(1))

--- a/src/main/java/com/vincent/logs/entity/ApiLogs.java
+++ b/src/main/java/com/vincent/logs/entity/ApiLogs.java
@@ -28,7 +28,19 @@ public class ApiLogs {
 
     private String level;
 
-    private String message;
+    private String traceId;
+
+    private String memberId;
+
+    private String method;
+
+    private String endpoint;
+
+    private String statusCode;
+
+    private String requestTime;
+
+    private String ip;
 
     @CreatedDate
     @Column(updatable = false)


### PR DESCRIPTION
## #️⃣연관된 이슈
> #173

## 📝작업 내용
로그 데이터베이스에 스웨거에 대한 요청도 저장되서 실제 사용자 요청을 파악하기 어려웠습니다. 그래서 스웨거에 대한 요청은 로깅하지 않게 개선했습니다.
또한 데이터베이스에 로그 메세지를 그대로 저장해서 가독성이 떨어져서, 이를 분리해서 저장되게 했습니다.