### PR TITLE
:recycle: 멤버 테스트 코드 모킹 제거

### DIFF
--- a/src/test/java/com/vincent/config/redis/service/RedisServiceTest.java
+++ b/src/test/java/com/vincent/config/redis/service/RedisServiceTest.java
@@ -28,6 +28,7 @@ import org.springframework.data.redis.core.ValueOperations;
 
 @ExtendWith(MockitoExtension.class)
 class RedisServiceTest {
+
     @Mock
     private RefreshTokenRepository refreshTokenRepository;
 
@@ -163,7 +164,8 @@ class RedisServiceTest {
         redisService.blacklist(accessToken);
 
         // then
-        verify(valueOperations, times(1)).set(eq(accessToken), eq("logout"), eq(expireAccessMs), eq(TimeUnit.MILLISECONDS));
+        verify(valueOperations, times(1)).set(eq(accessToken), eq("logout"), eq(expireAccessMs),
+            eq(TimeUnit.MILLISECONDS));
     }
 
     @Test

--- a/src/test/java/com/vincent/config/redis/service/TestRedisService.java
+++ b/src/test/java/com/vincent/config/redis/service/TestRedisService.java
@@ -1,0 +1,10 @@
+package com.vincent.config.redis.service;
+
+import com.vincent.domain.member.TestJwtProvider;
+
+public class TestRedisService extends RedisService {
+
+    public TestRedisService() {
+        super(new TestRefreshTokenRepository(), new TestRedisTemplate(), new TestJwtProvider());
+    }
+}

--- a/src/test/java/com/vincent/config/redis/service/TestRedisTemplate.java
+++ b/src/test/java/com/vincent/config/redis/service/TestRedisTemplate.java
@@ -1,0 +1,192 @@
+package com.vincent.config.redis.service;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.springframework.data.redis.connection.BitFieldSubCommands;
+import org.springframework.data.redis.core.RedisOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+public class TestRedisTemplate extends RedisTemplate<String, Object> {
+
+    public TestRedisTemplate() {
+        super();
+    }
+
+    public ValueOperations<String, Object> opsForValue() {
+        return new FakeValueOperations();
+    }
+
+    private final Map<String, Object> store = new HashMap<>();
+
+    public void set(String key, Object value, long timeout, TimeUnit unit) {
+        store.put(key, value);
+    }
+
+    // 키가 존재하는지 확인
+    public Boolean hasKey(String key) {
+        return store.containsKey(key);
+    }
+
+    // 키 삭제 및 성공 여부 반환
+    public Boolean delete(String key) {
+        return store.remove(key) != null;
+    }
+
+    // 저장소를 비우는 메서드
+    public void clear() {
+        store.clear();
+    }
+
+    // 저장소에 특정 키의 값을 반환하는 메서드 추가
+    public Object get(String key) {
+        return store.get(key);
+    }
+
+    public class FakeValueOperations implements ValueOperations<String, Object> {
+
+        @Override
+        public void set(String key, Object value) {
+
+        }
+
+        @Override
+        public void set(String key, Object value, long timeout, TimeUnit unit) {
+            store.put(key, value);
+        }
+
+        @Override
+        public Boolean setIfAbsent(String key, Object value) {
+            return null;
+        }
+
+        @Override
+        public Boolean setIfAbsent(String key, Object value, long timeout, TimeUnit unit) {
+            return null;
+        }
+
+        @Override
+        public Boolean setIfPresent(String key, Object value) {
+            return null;
+        }
+
+        @Override
+        public Boolean setIfPresent(String key, Object value, long timeout, TimeUnit unit) {
+            return null;
+        }
+
+        @Override
+        public void multiSet(Map<? extends String, ?> map) {
+
+        }
+
+        @Override
+        public Boolean multiSetIfAbsent(Map<? extends String, ?> map) {
+            return null;
+        }
+
+        @Override
+        public Object get(Object key) {
+            return null;
+        }
+
+        @Override
+        public Object getAndDelete(String key) {
+            return null;
+        }
+
+        @Override
+        public Object getAndExpire(String key, long timeout, TimeUnit unit) {
+            return null;
+        }
+
+        @Override
+        public Object getAndExpire(String key, Duration timeout) {
+            return null;
+        }
+
+        @Override
+        public Object getAndPersist(String key) {
+            return null;
+        }
+
+        @Override
+        public Object getAndSet(String key, Object value) {
+            return null;
+        }
+
+        @Override
+        public List<Object> multiGet(Collection<String> keys) {
+            return List.of();
+        }
+
+        @Override
+        public Long increment(String key) {
+            return 0L;
+        }
+
+        @Override
+        public Long increment(String key, long delta) {
+            return 0L;
+        }
+
+        @Override
+        public Double increment(String key, double delta) {
+            return 0.0;
+        }
+
+        @Override
+        public Long decrement(String key) {
+            return 0L;
+        }
+
+        @Override
+        public Long decrement(String key, long delta) {
+            return 0L;
+        }
+
+        @Override
+        public Integer append(String key, String value) {
+            return 0;
+        }
+
+        @Override
+        public String get(String key, long start, long end) {
+            return "";
+        }
+
+        @Override
+        public void set(String key, Object value, long offset) {
+
+        }
+
+        @Override
+        public Long size(String key) {
+            return 0L;
+        }
+
+        @Override
+        public Boolean setBit(String key, long offset, boolean value) {
+            return null;
+        }
+
+        @Override
+        public Boolean getBit(String key, long offset) {
+            return null;
+        }
+
+        @Override
+        public List<Long> bitField(String key, BitFieldSubCommands subCommands) {
+            return List.of();
+        }
+
+        @Override
+        public RedisOperations<String, Object> getOperations() {
+            return null;
+        }
+    }
+}

--- a/src/test/java/com/vincent/config/redis/service/TestRefreshTokenRepository.java
+++ b/src/test/java/com/vincent/config/redis/service/TestRefreshTokenRepository.java
@@ -1,0 +1,88 @@
+package com.vincent.config.redis.service;
+
+import com.vincent.config.redis.entity.RefreshToken;
+import com.vincent.config.redis.repository.RefreshTokenRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+public class TestRefreshTokenRepository implements RefreshTokenRepository {
+
+    List<RefreshToken> refreshTokens = new ArrayList<>();
+
+    @Override
+    public Optional<RefreshToken> findByRefreshToken(String refreshToken) {
+        return refreshTokens.stream()
+            .filter(token -> token.getRefreshToken().equals(refreshToken))
+            .findFirst();
+    }
+
+    @Override
+    public Optional<RefreshToken> findById(Long aLong) {
+        return refreshTokens.stream()
+            .filter(token -> token.getMemberId().equals(aLong))
+            .findFirst();
+    }
+
+    @Override
+    public void deleteByMemberId(Long memberId) {
+        refreshTokens.removeIf(token -> token.getMemberId().equals(memberId));
+    }
+
+    @Override
+    public <S extends RefreshToken> S save(S entity) {
+        refreshTokens.add(entity);
+        return entity;
+    }
+
+    @Override
+    public boolean existsById(Long memberId) {
+        return refreshTokens.stream()
+            .anyMatch(token -> token.getMemberId().equals(memberId));
+    }
+
+    @Override
+    public <S extends RefreshToken> Iterable<S> saveAll(Iterable<S> entities) {
+        return null;
+    }
+
+    @Override
+    public Iterable<RefreshToken> findAll() {
+        return null;
+    }
+
+    @Override
+    public Iterable<RefreshToken> findAllById(Iterable<Long> longs) {
+        return null;
+    }
+
+    @Override
+    public long count() {
+        return 0;
+    }
+
+    @Override
+    public void deleteById(Long aLong) {
+
+    }
+
+    @Override
+    public void delete(RefreshToken entity) {
+
+    }
+
+    @Override
+    public void deleteAllById(Iterable<? extends Long> longs) {
+
+    }
+
+    @Override
+    public void deleteAll(Iterable<? extends RefreshToken> entities) {
+
+    }
+
+    @Override
+    public void deleteAll() {
+
+    }
+}

--- a/src/test/java/com/vincent/domain/member/TestMemberDataService.java
+++ b/src/test/java/com/vincent/domain/member/TestMemberDataService.java
@@ -1,0 +1,10 @@
+package com.vincent.domain.member;
+
+import com.vincent.domain.member.service.data.MemberDataService;
+
+public class TestMemberDataService extends MemberDataService {
+
+    public TestMemberDataService() {
+        super(new TestMemberRepository());
+    }
+}

--- a/src/test/java/com/vincent/domain/member/TestMemberRepository.java
+++ b/src/test/java/com/vincent/domain/member/TestMemberRepository.java
@@ -1,0 +1,189 @@
+package com.vincent.domain.member;
+
+import com.vincent.domain.member.entity.Member;
+import com.vincent.domain.member.entity.enums.SocialType;
+import com.vincent.domain.member.repository.MemberRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import org.springframework.data.domain.Example;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.repository.query.FluentQuery.FetchableFluentQuery;
+
+public class TestMemberRepository implements MemberRepository {
+
+    List<Member> members = new ArrayList<>();
+
+    @Override
+    public Optional<Member> findByEmail(String email) {
+        return members.stream()
+            .filter(member -> member.getEmail().equals(email))
+            .findFirst();
+    }
+
+    @Override
+    public Optional<Member> findByEmailAndSocialType(String email, SocialType socialType) {
+        return members.stream()
+            .filter(member -> member.getEmail().equals(email) && member.getSocialType()
+                .equals(socialType))
+            .findFirst();
+    }
+
+
+    @Override
+    public <S extends Member> S save(S entity) {
+        members.add(entity);
+        return entity;
+    }
+
+    @Override
+    public Optional<Member> findById(Long aLong) {
+        return members.stream()
+            .filter(member -> member.getId().equals(aLong))
+            .findFirst();
+    }
+
+    @Override
+    public void flush() {
+
+    }
+
+    @Override
+    public <S extends Member> S saveAndFlush(S entity) {
+        return null;
+    }
+
+    @Override
+    public <S extends Member> List<S> saveAllAndFlush(Iterable<S> entities) {
+        return List.of();
+    }
+
+    @Override
+    public void deleteAllInBatch(Iterable<Member> entities) {
+
+    }
+
+    @Override
+    public void deleteAllByIdInBatch(Iterable<Long> longs) {
+
+    }
+
+    @Override
+    public void deleteAllInBatch() {
+
+    }
+
+    @Override
+    public Member getOne(Long aLong) {
+        return null;
+    }
+
+    @Override
+    public Member getById(Long aLong) {
+        return null;
+    }
+
+    @Override
+    public Member getReferenceById(Long aLong) {
+        return null;
+    }
+
+    @Override
+    public <S extends Member> Optional<S> findOne(Example<S> example) {
+        return Optional.empty();
+    }
+
+    @Override
+    public <S extends Member> List<S> findAll(Example<S> example) {
+        return List.of();
+    }
+
+    @Override
+    public <S extends Member> List<S> findAll(Example<S> example, Sort sort) {
+        return List.of();
+    }
+
+    @Override
+    public <S extends Member> Page<S> findAll(Example<S> example, Pageable pageable) {
+        return null;
+    }
+
+    @Override
+    public <S extends Member> long count(Example<S> example) {
+        return 0;
+    }
+
+    @Override
+    public <S extends Member> boolean exists(Example<S> example) {
+        return false;
+    }
+
+    @Override
+    public <S extends Member, R> R findBy(Example<S> example,
+        Function<FetchableFluentQuery<S>, R> queryFunction) {
+        return null;
+    }
+
+    @Override
+    public <S extends Member> List<S> saveAll(Iterable<S> entities) {
+        return List.of();
+    }
+
+    @Override
+    public boolean existsById(Long aLong) {
+        return false;
+    }
+
+    @Override
+    public List<Member> findAll() {
+        return List.of();
+    }
+
+    @Override
+    public List<Member> findAllById(Iterable<Long> longs) {
+        return List.of();
+    }
+
+    @Override
+    public long count() {
+        return 0;
+    }
+
+    @Override
+    public void deleteById(Long aLong) {
+
+    }
+
+    @Override
+    public void delete(Member entity) {
+
+    }
+
+    @Override
+    public void deleteAllById(Iterable<? extends Long> longs) {
+
+    }
+
+    @Override
+    public void deleteAll(Iterable<? extends Member> entities) {
+
+    }
+
+    @Override
+    public void deleteAll() {
+
+    }
+
+    @Override
+    public List<Member> findAll(Sort sort) {
+        return List.of();
+    }
+
+    @Override
+    public Page<Member> findAll(Pageable pageable) {
+        return null;
+    }
+}

--- a/src/test/java/com/vincent/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/vincent/domain/member/service/MemberServiceTest.java
@@ -1,6 +1,9 @@
 package com.vincent.domain.member.service;
 
 import com.vincent.config.security.provider.JwtProvider;
+import com.vincent.domain.member.TestJwtProvider;
+import com.vincent.domain.member.TestMemberDataService;
+import com.vincent.config.redis.service.TestRedisService;
 import com.vincent.domain.member.entity.Member;
 import com.vincent.domain.member.entity.enums.SocialType;
 import com.vincent.domain.member.service.MemberService.LoginResult;
@@ -8,193 +11,157 @@ import com.vincent.domain.member.service.MemberService.ReissueResult;
 import com.vincent.domain.member.service.data.MemberDataService;
 import com.vincent.config.redis.entity.RefreshToken;
 import com.vincent.config.redis.service.RedisService;
+import com.vincent.exception.handler.JwtInvalidHandler;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@ExtendWith(MockitoExtension.class)
 class MemberServiceTest {
 
-    @Mock
     private MemberDataService memberDataService;
-    @Mock
     private RedisService redisService;
-    @Mock
     private JwtProvider jwtProvider;
-
-    @InjectMocks
     private MemberService memberService;
+
+    @BeforeEach
+    void setUp() {
+        memberDataService = new TestMemberDataService();
+        redisService = new TestRedisService();
+        jwtProvider = new TestJwtProvider();
+        memberService = new MemberService(memberDataService, redisService, jwtProvider);
+    }
 
     @Test
     public void 로그인성공() {
-        //given
+        // given
         Member member = Member.builder()
             .id(1L)
             .email("test@gmail.com")
             .socialType(SocialType.KAKAO)
             .build();
+        memberDataService.save(member);
+
         String email = "test@gmail.com";
-        String accessToken = "access";
-        RefreshToken refreshToken = RefreshToken.builder()
-            .memberId(member.getId())
-            .refreshToken("refresh")
-            .build();
-
-        //when
-        when(memberDataService.findByEmailAndSocialType(email, SocialType.KAKAO)).thenReturn(
-            Optional.of(member));
-        when(jwtProvider.createAccessToken(member.getId(), member.getEmail(),
-            member.getSocialType())).thenReturn(accessToken);
-        when(redisService.generateRefreshToken(member)).thenReturn(refreshToken);
+        // when
         LoginResult result = memberService.login(email, SocialType.KAKAO);
-
-        //then
-        verify(memberDataService, times(1)).findByEmailAndSocialType(email, SocialType.KAKAO);
-        verify(jwtProvider, times(1)).createAccessToken(1L, "test@gmail.com", SocialType.KAKAO);
-        verify(redisService, times(1)).generateRefreshToken(member);
-        Assertions.assertEquals(result.getAccessToken(), accessToken);
-        Assertions.assertEquals(result.getRefreshToken(), refreshToken.getRefreshToken());
-
+        // then
+        Assertions.assertNotNull(result.getAccessToken());
+        Assertions.assertNotNull(result.getRefreshToken());
     }
 
     @Test
     public void 로그인성공_회원가입() {
-        //given
+        // given
+        String email = "test@gmail.com";
+        SocialType socialType = SocialType.KAKAO;
         Member member = Member.builder()
             .id(1L)
-            .email("test@gmail.com")
-            .socialType(SocialType.KAKAO)
-            .build();
-        String email = "test@gmail.com";
-        String accessToken = "access";
-        RefreshToken refreshToken = RefreshToken.builder()
-            .memberId(member.getId())
-            .refreshToken("refresh")
+            .email(email)
+            .socialType(socialType)
             .build();
 
-        //when
-        when(memberDataService.findByEmailAndSocialType(email, SocialType.KAKAO)).thenReturn(
-            Optional.empty());
-        when(memberDataService.save(any(Member.class))).thenReturn(member);
-        when(jwtProvider.createAccessToken(member.getId(), member.getEmail(),
-            member.getSocialType())).thenReturn(accessToken);
-        when(redisService.generateRefreshToken(member)).thenReturn(refreshToken);
-        LoginResult result = memberService.login(email, SocialType.KAKAO);
+        // when
+        LoginResult result = memberService.login(email, socialType);
 
-        //then
-        verify(memberDataService, times(1)).findByEmailAndSocialType(email, SocialType.KAKAO);
-        verify(memberDataService, times(1)).save(any(Member.class));
-        verify(jwtProvider, times(1)).createAccessToken(1L, "test@gmail.com", SocialType.KAKAO);
-        verify(redisService, times(1)).generateRefreshToken(member);
-        Assertions.assertEquals(result.getAccessToken(), accessToken);
-        Assertions.assertEquals(result.getRefreshToken(), refreshToken.getRefreshToken());
+        // then
+        Assertions.assertNotNull(result.getAccessToken());
+        Assertions.assertNotNull(result.getRefreshToken());
     }
 
     @Test
     public void 토큰재발급() {
-        //given
-        String token = "token";
-        String newToken = "token2";
+        // given
         Member member = Member.builder()
             .id(1L)
             .email("test@gmail.com")
             .socialType(SocialType.KAKAO)
             .build();
-        RefreshToken refreshToken = RefreshToken.builder()
-            .memberId(member.getId())
-            .refreshToken("refresh")
-            .build();
-        RefreshToken refreshToken2 = RefreshToken.builder()
-            .memberId(member.getId())
-            .refreshToken("refresh2")
-            .build();
+        memberDataService.save(member);
+        String refreshToken = redisService.generateRefreshToken(member).getRefreshToken();
 
-        //when
-        doNothing().when(jwtProvider).validateToken(token);
-        when(jwtProvider.getMemberId(token)).thenReturn(1L);
-        when(redisService.findByMemberId(1L)).thenReturn(refreshToken);
-        when(memberDataService.findById(1L)).thenReturn(member);
-        when(jwtProvider.createAccessToken(member.getId(), member.getEmail(),
-            member.getSocialType())).thenReturn("token2");
-        when(redisService.regenerateRefreshToken(member, refreshToken)).thenReturn(refreshToken2);
-        ReissueResult result = memberService.reissue(token);
+        // when
+        ReissueResult result = memberService.reissue(refreshToken);
 
-        //then
-        verify(jwtProvider, times(1)).getMemberId(token);
-        verify(jwtProvider, times(1)).createAccessToken(member.getId(), member.getEmail(),
-            member.getSocialType());
-        verify(redisService, times(1)).regenerateRefreshToken(member, refreshToken);
-        Assertions.assertEquals(result.getAccessToken(), newToken);
-        Assertions.assertEquals(result.getRefreshToken(), refreshToken2.getRefreshToken());
+        // then
+        Assertions.assertNotNull(result.getAccessToken());
+        Assertions.assertNotNull(result.getRefreshToken());
     }
 
     @Test
     public void 로그아웃_리프레시토큰존재() {
         //given
-        String accessToken = "access";
-        String refreshToken = "refresh";
-        Long memberId = 1L;
+        Member member = Member.builder()
+            .id(1L)
+            .email("test@gmail.com")
+            .socialType(SocialType.KAKAO)
+            .build();
+        memberDataService.save(member);
+
+        String accessToken = jwtProvider.createAccessToken(member.getId(), member.getEmail(),
+            member.getSocialType());
+        String refreshToken = redisService.generateRefreshToken(member).getRefreshToken();
 
         //when
-        when(jwtProvider.getMemberId(refreshToken)).thenReturn(memberId);
-        when(redisService.exists(memberId)).thenReturn(true);
-        doNothing().when(redisService).delete(memberId);
-        doNothing().when(redisService).blacklist(accessToken);
         memberService.logout(accessToken, refreshToken);
 
         //then
-        verify(jwtProvider, times(1)).getMemberId(refreshToken);
-        verify(redisService, times(1)).exists(memberId);
-        verify(redisService, times(1)).delete(memberId);
-        verify(redisService, times(1)).blacklist(accessToken);
+        assertFalse(redisService.exists(member.getId()), "리프레시 토큰이 Redis에서 삭제되지 않았습니다.");
+        assertTrue(redisService.isBlacklisted(accessToken), "엑세스 토큰이 블랙리스트에 추가되지 않았습니다.");
     }
 
     @Test
     public void 로그아웃_리프레시토큰존재하지않음() {
         //given
-        String accessToken = "access";
-        String refreshToken = "refresh";
-        Long memberId = 1L;
+        Member member = Member.builder()
+            .id(1L)
+            .email("test@gmail.com")
+            .socialType(SocialType.KAKAO)
+            .build();
+        memberDataService.save(member);
+        String accessToken = jwtProvider.createAccessToken(member.getId(), member.getEmail(),
+            member.getSocialType());
+        String refreshToken = jwtProvider.createRefreshToken(member.getId(), member.getEmail());
 
         //when
-        when(jwtProvider.getMemberId(refreshToken)).thenReturn(memberId);
-        when(redisService.exists(memberId)).thenReturn(false);
-        doNothing().when(redisService).blacklist(accessToken);
         memberService.logout(accessToken, refreshToken);
 
         //then
-        verify(jwtProvider, times(1)).getMemberId(refreshToken);
-        verify(redisService, times(1)).exists(memberId);
-        verify(redisService, times(1)).blacklist(accessToken);
+        assertFalse(redisService.exists(member.getId()), "리프레시 토큰이 Redis에서 삭제되지 않았습니다.");
+        assertTrue(redisService.isBlacklisted(accessToken), "엑세스 토큰이 블랙리스트에 추가되지 않았습니다.");
     }
 
     @Test
     public void 회원탈퇴() {
         //given
-        Long memberId = 1L;
         Member member = Member.builder()
             .id(1L)
             .email("test@gmail.com")
+            .socialType(SocialType.KAKAO)
             .build();
+        memberDataService.save(member);
 
         //when
-        when(memberDataService.findById(memberId)).thenReturn(member);
-        memberService.withdraw(memberId);
+        memberService.withdraw(member.getId());
 
         //then
-        verify(memberDataService, times(1)).findById(memberId);
-        Assertions.assertEquals(member.isWithdraw(), true);
-
+        assertTrue(member.isWithdraw(), "회원 상태가 탈퇴 상태로 변경되지 않았습니다.");
+        Member optionalMember = memberDataService.findById(member.getId());
+        assertNotNull(optionalMember, "데이터베이스에서 회원을 찾을 수 없습니다.");
+        assertTrue(optionalMember.isWithdraw(), "데이터베이스에 저장된 회원 상태가 탈퇴 상태가 아닙니다.");
     }
 
 //

--- a/src/test/java/com/vincent/domain/member/service/data/MemberDataServiceTest.java
+++ b/src/test/java/com/vincent/domain/member/service/data/MemberDataServiceTest.java
@@ -1,83 +1,75 @@
 package com.vincent.domain.member.service.data;
 
 
-import static org.mockito.Mockito.when;
 
 import com.vincent.apipayload.status.ErrorStatus;
+import com.vincent.domain.member.TestMemberRepository;
 import com.vincent.domain.member.entity.Member;
 import com.vincent.domain.member.entity.enums.SocialType;
-import com.vincent.domain.member.repository.MemberRepository;
 import com.vincent.exception.handler.ErrorHandler;
 import java.util.Optional;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
 class MemberDataServiceTest {
 
-    @Mock
-    private MemberRepository memberRepository;
-
-    @InjectMocks
+    private TestMemberRepository memberRepository;
     private MemberDataService memberDataService;
+
+    @BeforeEach()
+    void setUp() {
+        memberRepository = new TestMemberRepository();
+        memberDataService = new MemberDataService(memberRepository);
+    }
 
     @Test
     void 이메일로사용자찾기() {
-        //given
-        String email = "test@gmail.com";
-
+        // given
         Member member = Member.builder()
             .id(1L)
             .email("test@gmail.com")
             .build();
+        memberRepository.save(member);
 
-        //when
-        when(memberRepository.findByEmail(email)).thenReturn(Optional.of(member));
+        // when
+        Optional<Member> result = memberDataService.findByEmail("test@gmail.com");
 
-        //then
-        Optional<Member> result = memberDataService.findByEmail(email);
+        // then
+        Assertions.assertTrue(result.isPresent());
         Assertions.assertEquals(result.get(), member);
     }
 
     @Test
     void 이메일과소셜로사용자찾기() {
         //given
-        String email = "test@gmail.com";
-        SocialType socialType = SocialType.KAKAO;
-
         Member member = Member.builder()
             .id(1L)
             .email("test@gmail.com")
             .socialType(SocialType.KAKAO)
             .build();
+        memberRepository.save(member);
 
         //when
-        when(memberRepository.findByEmailAndSocialType(email, socialType)).thenReturn(Optional.of(member));
-
+        Optional<Member> result = memberDataService.findByEmailAndSocialType("test@gmail.com",
+            SocialType.KAKAO);
         //then
-        Optional<Member> result = memberDataService.findByEmailAndSocialType(email, socialType);
         Assertions.assertEquals(result.get(), member);
     }
 
     @Test
     void 아이디로사용자찾기() {
         //given
-        Long id = 1L;
-
         Member member = Member.builder()
             .id(1L)
             .email("test@gmail.com")
             .build();
+        memberRepository.save(member);
 
         //when
-        when(memberRepository.findById(id)).thenReturn(Optional.of(member));
+        Member result = memberDataService.findById(1L);
 
         //then
-        Member result = memberDataService.findById(id);
         Assertions.assertEquals(result, member);
     }
 
@@ -87,12 +79,9 @@ class MemberDataServiceTest {
         Long id = 1L;
 
         //when
-        when(memberRepository.findById(id)).thenReturn(Optional.empty());
-
-        //then
         ErrorHandler thrown = Assertions.assertThrows(ErrorHandler.class,
             () -> memberDataService.findById(id));
-
+        //then
         Assertions.assertEquals(thrown.getCode(), ErrorStatus.MEMBER_NOT_FOUND);
     }
 
@@ -105,10 +94,9 @@ class MemberDataServiceTest {
             .build();
 
         //when
-        when(memberRepository.save(member)).thenReturn(member);
+        Member result = memberDataService.save(member);
 
         //then
-        Member result = memberDataService.save(member);
         Assertions.assertEquals(result, member);
     }
 }

--- a/src/test/java/com/vincent/e2e/domain/MemberControllerTest.java
+++ b/src/test/java/com/vincent/e2e/domain/MemberControllerTest.java
@@ -1,0 +1,51 @@
+//package com.vincent.e2e.domain;
+//
+//import static org.assertj.core.api.Assertions.assertThat;
+//import static org.junit.jupiter.api.Assertions.assertEquals;
+//import static org.junit.jupiter.api.Assertions.assertNotNull;
+//
+//import com.vincent.apipayload.ApiResponse;
+//import com.vincent.domain.member.controller.dto.MemberRequestDto;
+//import com.vincent.domain.member.controller.dto.MemberResponseDto;
+//import com.vincent.domain.member.controller.dto.MemberResponseDto.Login;
+//import com.vincent.domain.member.entity.Member;
+//import com.vincent.domain.member.entity.enums.SocialType;
+//import com.vincent.domain.member.repository.MemberRepository;
+//import org.junit.jupiter.api.Test;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.boot.test.context.SpringBootTest;
+//import org.springframework.boot.test.web.client.TestRestTemplate;
+//import org.springframework.boot.test.web.server.LocalServerPort;
+//import org.springframework.http.HttpStatus;
+//import org.springframework.http.ResponseEntity;
+//import org.springframework.test.context.ActiveProfiles;
+//
+//@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+//@ActiveProfiles("test")
+//public class MemberControllerTest {
+//    @Autowired
+//    private TestRestTemplate restTemplate;
+//
+//    @LocalServerPort
+//    private int port;
+//
+//    @Autowired
+//    private MemberRepository memberRepository;
+//
+//    @Test
+//    void 로그인() {
+//        // Given
+//        MemberRequestDto.Login requestDto = new MemberRequestDto.Login("test@gmail.com", SocialType.KAKAO);
+//
+//        // When
+//        ResponseEntity<ApiResponse> response = restTemplate.postForEntity(
+//            "/v1/login", requestDto, ApiResponse.class
+//        );
+//
+//        // Then
+//        assertEquals(HttpStatus.OK, response.getStatusCode());
+//        assertNotNull(response.getBody());
+//        assertEquals("COMMON200", response.getBody().getCode());
+//    }
+//
+//}


### PR DESCRIPTION
## #️⃣연관된 이슈
> #177 

## 📝작업 내용
멤버쪽 테스트 코드에서 모킹을 제거 했습니다. 
기존 코드는 의존성들을 Mockito로 모킹하여 테스트 했는데, 모킹의 문제는 단순히 메서드 호출에 대한 예상 결과를 반환하기 때문에 내부 로직이나 데이터베이스 쿼리의 실제 동작과 다를 수 있었습니다.
이를 해결하기 위해, 테스트에 필요한 의존성들을 직접 구현하여 테스트 할 수 있게 변경했습니다.

이번에 모킹을 제거해서 테스트 코드를 작성하는 것이 처음이어서 틀린 부분이 있을 수 있습니다..😅😅