### PR TITLE
[Fix/176] 층 콘센트 조회 성능 개선 & 소켓 테스트 코드 모킹 제거

### DIFF
--- a/src/main/java/com/vincent/domain/socket/repository/customsocket/CustomSocketRepository.java
+++ b/src/main/java/com/vincent/domain/socket/repository/customsocket/CustomSocketRepository.java
@@ -1,9 +1,13 @@
 package com.vincent.domain.socket.repository.customsocket;
 
 import com.vincent.domain.socket.controller.dto.SocketResponseDto.SocketPlace;
+import com.vincent.domain.socket.entity.Socket;
+import java.util.List;
 
 public interface CustomSocketRepository {
 
     SocketPlace findSocketPlaceBySocketId(Long socketId);
+
+    List<Socket> findSocketListByBuildingIdAndLevel(Long buildingId, Integer level);
 
 }

--- a/src/main/java/com/vincent/domain/socket/repository/customsocket/CustomSocketRepositoryImpl.java
+++ b/src/main/java/com/vincent/domain/socket/repository/customsocket/CustomSocketRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.vincent.domain.socket.repository.customsocket;
 import com.vincent.domain.building.controller.dto.BuildingResponseDto.SpaceInfoProjection;
 import com.vincent.domain.building.repository.customspace.CustomSpaceRepository;
 import com.vincent.domain.socket.controller.dto.SocketResponseDto.SocketPlace;
+import com.vincent.domain.socket.entity.Socket;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import java.util.List;
@@ -31,4 +32,19 @@ public class CustomSocketRepositoryImpl implements CustomSocketRepository {
     }
 
 
+    @Override
+    public List<Socket> findSocketListByBuildingIdAndLevel(Long buildingId, Integer level) {
+
+        String jpql = "SELECT socket "
+            + "FROM Socket socket "
+            + "JOIN socket.space space "
+            + "JOIN space.floor floor "
+            + "JOIN floor.building building "
+            + "WHERE building.id = :buildingId AND floor.level = :level";
+
+        return entityManager.createQuery(jpql, Socket.class)
+            .setParameter("buildingId", buildingId)
+            .setParameter("level", level)
+            .getResultList();
+    }
 }

--- a/src/main/java/com/vincent/domain/socket/service/SocketService.java
+++ b/src/main/java/com/vincent/domain/socket/service/SocketService.java
@@ -21,9 +21,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class SocketService {
 
     private final SocketDataService socketDataService;
-    private final BuildingDataService buildingDataService;
-    private final FloorDataService floorDataService;
-    private final SpaceDataService spaceDataService;
 
     public Socket getSocketInfo(Long socketId) {
         return socketDataService.findById(socketId);

--- a/src/main/java/com/vincent/domain/socket/service/SocketService.java
+++ b/src/main/java/com/vincent/domain/socket/service/SocketService.java
@@ -31,15 +31,7 @@ public class SocketService {
 
     public List<Socket> getSocketList(Long buildingId, int level) {
 
-        Building building = buildingDataService.findById(buildingId);
-        Floor floor = floorDataService.findByBuildingAndLevel(building, level);
-        List<Space> spaces = spaceDataService.findAllByFloor(floor);
-
-        return spaces.stream()
-            .map(space -> socketDataService.findAllBySpace(space))
-            .flatMap(sockets -> sockets.stream())
-            .collect(Collectors.toList());
-
+        return socketDataService.findSocketListByBuildingIdAndLevel(buildingId, level);
     }
 
     public SocketResponseDto.SocketPlace getSocketPlace(Long socketId) {

--- a/src/main/java/com/vincent/domain/socket/service/data/SocketDataService.java
+++ b/src/main/java/com/vincent/domain/socket/service/data/SocketDataService.java
@@ -35,4 +35,8 @@ public class SocketDataService {
             .orElseThrow(() -> new ErrorHandler(ErrorStatus.SOCKET_NOT_FOUND));
     }
 
+    public List<Socket> findSocketListByBuildingIdAndLevel(Long buildingId, Integer level) {
+        return socketRepository.findSocketListByBuildingIdAndLevel(buildingId, level);
+    }
+
 }

--- a/src/test/java/com/vincent/domain/building/TestBuildingRepository.java
+++ b/src/test/java/com/vincent/domain/building/TestBuildingRepository.java
@@ -1,0 +1,180 @@
+package com.vincent.domain.building;
+
+import com.vincent.domain.building.entity.Building;
+import com.vincent.domain.building.repository.BuildingRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import org.springframework.data.domain.Example;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.repository.query.FluentQuery.FetchableFluentQuery;
+
+public class TestBuildingRepository implements BuildingRepository {
+
+    List<Building> buildings = new ArrayList<>();
+    @Override
+    public Page<Building> findByNameContainingOrderBySimilarity(String keyword, PageRequest pageRequest) {
+        return null;
+    }
+
+    @Override
+    public List<Building> findAllByLocation(Double longitudeLower, Double longitudeUpper, Double latitudeLower,
+        Double latitudeUpper) {
+        return null;
+    }
+
+    @Override
+    public void flush() {
+
+    }
+
+    @Override
+    public <S extends Building> S saveAndFlush(S entity) {
+        return null;
+    }
+
+    @Override
+    public <S extends Building> List<S> saveAllAndFlush(Iterable<S> entities) {
+        return null;
+    }
+
+    @Override
+    public void deleteAllInBatch(Iterable<Building> entities) {
+
+    }
+
+    @Override
+    public void deleteAllByIdInBatch(Iterable<Long> longs) {
+
+    }
+
+    @Override
+    public void deleteAllInBatch() {
+
+    }
+
+    @Override
+    public Building getOne(Long aLong) {
+        return null;
+    }
+
+    @Override
+    public Building getById(Long aLong) {
+        return null;
+    }
+
+    @Override
+    public Building getReferenceById(Long aLong) {
+        return null;
+    }
+
+    @Override
+    public <S extends Building> Optional<S> findOne(Example<S> example) {
+        return Optional.empty();
+    }
+
+    @Override
+    public <S extends Building> List<S> findAll(Example<S> example) {
+        return null;
+    }
+
+    @Override
+    public <S extends Building> List<S> findAll(Example<S> example, Sort sort) {
+        return null;
+    }
+
+    @Override
+    public <S extends Building> Page<S> findAll(Example<S> example, Pageable pageable) {
+        return null;
+    }
+
+    @Override
+    public <S extends Building> long count(Example<S> example) {
+        return 0;
+    }
+
+    @Override
+    public <S extends Building> boolean exists(Example<S> example) {
+        return false;
+    }
+
+    @Override
+    public <S extends Building, R> R findBy(Example<S> example, Function<FetchableFluentQuery<S>, R> queryFunction) {
+        return null;
+    }
+
+    @Override
+    public <S extends Building> S save(S entity) {
+        buildings.add(entity);
+        return entity;
+    }
+
+    @Override
+    public <S extends Building> List<S> saveAll(Iterable<S> entities) {
+        return null;
+    }
+
+    @Override
+    public Optional<Building> findById(Long aLong) {
+        return Optional.empty();
+    }
+
+    @Override
+    public boolean existsById(Long aLong) {
+        return false;
+    }
+
+    @Override
+    public List<Building> findAll() {
+        return buildings;
+    }
+
+    @Override
+    public List<Building> findAllById(Iterable<Long> longs) {
+        return null;
+    }
+
+    @Override
+    public long count() {
+        return 0;
+    }
+
+    @Override
+    public void deleteById(Long aLong) {
+
+    }
+
+    @Override
+    public void delete(Building entity) {
+
+    }
+
+    @Override
+    public void deleteAllById(Iterable<? extends Long> longs) {
+
+    }
+
+    @Override
+    public void deleteAll(Iterable<? extends Building> entities) {
+
+    }
+
+    @Override
+    public void deleteAll() {
+
+    }
+
+    @Override
+    public List<Building> findAll(Sort sort) {
+        return null;
+    }
+
+    @Override
+    public Page<Building> findAll(Pageable pageable) {
+        return null;
+    }
+}

--- a/src/test/java/com/vincent/domain/building/TestFloorRepository.java
+++ b/src/test/java/com/vincent/domain/building/TestFloorRepository.java
@@ -1,0 +1,196 @@
+package com.vincent.domain.building;
+
+import com.vincent.domain.building.controller.dto.BuildingResponseDto.FloorInfoProjection;
+import com.vincent.domain.building.controller.dto.BuildingResponseDto.FloorWithSocket;
+import com.vincent.domain.building.entity.Building;
+import com.vincent.domain.building.entity.Floor;
+import com.vincent.domain.building.repository.FloorRepository;
+import com.vincent.domain.socket.entity.Socket;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.springframework.data.domain.Example;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.repository.query.FluentQuery.FetchableFluentQuery;
+
+public class TestFloorRepository implements FloorRepository {
+
+    List<Floor> floors = new ArrayList<>();
+
+
+
+    @Override
+    public Optional<Floor> findByBuildingAndLevel(Building building, Integer level) {
+        return floors.stream()
+            .filter(floor -> floor.getBuilding().equals(building) && floor.getLevel().equals(level))
+            .findFirst();
+    }
+
+    @Override
+    public FloorInfoProjection findFloorInfoByBuildingIdAndLevel(Long buildingId, int level) {
+        throw new UnsupportedOperationException("findFloorWithSocketListByBuildingId is not supported in TestFloorRepository");
+    }
+
+    @Override
+    public List<FloorWithSocket> findFloorWithSocketListByBuildingId(Long buildingId) {
+        throw new UnsupportedOperationException("findFloorWithSocketListByBuildingId is not supported in TestFloorRepository");
+
+
+    }
+
+
+    @Override
+    public void flush() {
+
+    }
+
+    @Override
+    public <S extends Floor> S saveAndFlush(S entity) {
+        return null;
+    }
+
+    @Override
+    public <S extends Floor> List<S> saveAllAndFlush(Iterable<S> entities) {
+        return null;
+    }
+
+    @Override
+    public void deleteAllInBatch(Iterable<Floor> entities) {
+
+    }
+
+    @Override
+    public void deleteAllByIdInBatch(Iterable<Long> longs) {
+
+    }
+
+    @Override
+    public void deleteAllInBatch() {
+
+    }
+
+    @Override
+    public Floor getOne(Long aLong) {
+        return null;
+    }
+
+    @Override
+    public Floor getById(Long aLong) {
+        return null;
+    }
+
+    @Override
+    public Floor getReferenceById(Long aLong) {
+        return null;
+    }
+
+    @Override
+    public <S extends Floor> Optional<S> findOne(Example<S> example) {
+        return Optional.empty();
+    }
+
+    @Override
+    public <S extends Floor> List<S> findAll(Example<S> example) {
+        return null;
+    }
+
+    @Override
+    public <S extends Floor> List<S> findAll(Example<S> example, Sort sort) {
+        return null;
+    }
+
+    @Override
+    public <S extends Floor> Page<S> findAll(Example<S> example, Pageable pageable) {
+        return null;
+    }
+
+    @Override
+    public <S extends Floor> long count(Example<S> example) {
+        return 0;
+    }
+
+    @Override
+    public <S extends Floor> boolean exists(Example<S> example) {
+        return false;
+    }
+
+    @Override
+    public <S extends Floor, R> R findBy(Example<S> example, Function<FetchableFluentQuery<S>, R> queryFunction) {
+        return null;
+    }
+
+    @Override
+    public <S extends Floor> S save(S entity) {
+        floors.add(entity);
+        return entity;
+    }
+
+    @Override
+    public <S extends Floor> List<S> saveAll(Iterable<S> entities) {
+        return null;
+    }
+
+    @Override
+    public Optional<Floor> findById(Long aLong) {
+        return Optional.empty();
+    }
+
+    @Override
+    public boolean existsById(Long aLong) {
+        return false;
+    }
+
+    @Override
+    public List<Floor> findAll() {
+        return floors;
+    }
+
+    @Override
+    public List<Floor> findAllById(Iterable<Long> longs) {
+        return null;
+    }
+
+    @Override
+    public long count() {
+        return 0;
+    }
+
+    @Override
+    public void deleteById(Long aLong) {
+
+    }
+
+    @Override
+    public void delete(Floor entity) {
+
+    }
+
+    @Override
+    public void deleteAllById(Iterable<? extends Long> longs) {
+
+    }
+
+    @Override
+    public void deleteAll(Iterable<? extends Floor> entities) {
+
+    }
+
+    @Override
+    public void deleteAll() {
+
+    }
+
+    @Override
+    public List<Floor> findAll(Sort sort) {
+        return null;
+    }
+
+    @Override
+    public Page<Floor> findAll(Pageable pageable) {
+        return null;
+    }
+}

--- a/src/test/java/com/vincent/domain/building/TestSpaceRepository.java
+++ b/src/test/java/com/vincent/domain/building/TestSpaceRepository.java
@@ -1,0 +1,181 @@
+package com.vincent.domain.building;
+
+import com.vincent.domain.building.controller.dto.BuildingResponseDto.SpaceInfoProjection;
+import com.vincent.domain.building.entity.Floor;
+import com.vincent.domain.building.entity.Space;
+import com.vincent.domain.building.repository.SpaceRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import org.springframework.data.domain.Example;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.repository.query.FluentQuery.FetchableFluentQuery;
+
+public class TestSpaceRepository implements SpaceRepository {
+
+
+    List<Space> spaces = new ArrayList<>();
+    @Override
+    public List<Space> findAllByFloor(Floor floor) {
+        return null;
+    }
+
+    @Override
+    public List<SpaceInfoProjection> findSpaceInfoByBuildingIdAndLevel(Long buildingId, int level) {
+        return null;
+    }
+
+    @Override
+    public void flush() {
+
+    }
+
+    @Override
+    public <S extends Space> S saveAndFlush(S entity) {
+        return null;
+    }
+
+    @Override
+    public <S extends Space> List<S> saveAllAndFlush(Iterable<S> entities) {
+        return null;
+    }
+
+    @Override
+    public void deleteAllInBatch(Iterable<Space> entities) {
+
+    }
+
+    @Override
+    public void deleteAllByIdInBatch(Iterable<Long> longs) {
+
+    }
+
+    @Override
+    public void deleteAllInBatch() {
+
+    }
+
+    @Override
+    public Space getOne(Long aLong) {
+        return null;
+    }
+
+    @Override
+    public Space getById(Long aLong) {
+        return null;
+    }
+
+    @Override
+    public Space getReferenceById(Long aLong) {
+        return null;
+    }
+
+    @Override
+    public <S extends Space> Optional<S> findOne(Example<S> example) {
+        return Optional.empty();
+    }
+
+    @Override
+    public <S extends Space> List<S> findAll(Example<S> example) {
+        return null;
+    }
+
+    @Override
+    public <S extends Space> List<S> findAll(Example<S> example, Sort sort) {
+        return null;
+    }
+
+    @Override
+    public <S extends Space> Page<S> findAll(Example<S> example, Pageable pageable) {
+        return null;
+    }
+
+    @Override
+    public <S extends Space> long count(Example<S> example) {
+        return 0;
+    }
+
+    @Override
+    public <S extends Space> boolean exists(Example<S> example) {
+        return false;
+    }
+
+    @Override
+    public <S extends Space, R> R findBy(Example<S> example, Function<FetchableFluentQuery<S>, R> queryFunction) {
+        return null;
+    }
+
+    @Override
+    public <S extends Space> S save(S entity) {
+        spaces.add(entity);
+        return entity;
+    }
+
+    @Override
+    public <S extends Space> List<S> saveAll(Iterable<S> entities) {
+        return null;
+    }
+
+    @Override
+    public Optional<Space> findById(Long aLong) {
+        return Optional.empty();
+    }
+
+    @Override
+    public boolean existsById(Long aLong) {
+        return false;
+    }
+
+    @Override
+    public List<Space> findAll() {
+        return spaces;
+    }
+
+    @Override
+    public List<Space> findAllById(Iterable<Long> longs) {
+        return null;
+    }
+
+    @Override
+    public long count() {
+        return 0;
+    }
+
+    @Override
+    public void deleteById(Long aLong) {
+
+    }
+
+    @Override
+    public void delete(Space entity) {
+
+    }
+
+    @Override
+    public void deleteAllById(Iterable<? extends Long> longs) {
+
+    }
+
+    @Override
+    public void deleteAll(Iterable<? extends Space> entities) {
+
+    }
+
+    @Override
+    public void deleteAll() {
+
+    }
+
+    @Override
+    public List<Space> findAll(Sort sort) {
+        return null;
+    }
+
+    @Override
+    public Page<Space> findAll(Pageable pageable) {
+        return null;
+    }
+}

--- a/src/test/java/com/vincent/domain/socket/TestSocketRepository.java
+++ b/src/test/java/com/vincent/domain/socket/TestSocketRepository.java
@@ -1,0 +1,255 @@
+package com.vincent.domain.socket;
+
+import com.vincent.apipayload.status.ErrorStatus;
+import com.vincent.domain.building.entity.Building;
+import com.vincent.domain.building.entity.Floor;
+import com.vincent.domain.building.entity.Space;
+import com.vincent.domain.socket.controller.dto.SocketResponseDto.SocketPlace;
+import com.vincent.domain.socket.entity.Socket;
+import com.vincent.domain.socket.repository.SocketRepository;
+import com.vincent.exception.handler.ErrorHandler;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.springframework.data.domain.Example;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.repository.query.FluentQuery.FetchableFluentQuery;
+
+public class TestSocketRepository implements SocketRepository {
+
+    List<Socket> sockets = new ArrayList<>();
+    List<Space> spaces = new ArrayList<>();
+    List<Floor> floors = new ArrayList<>();
+    List<Building> buildings = new ArrayList<>();
+
+
+
+    @Override
+    public List<Socket> findAllBySpace(Space space) {
+        return sockets.stream()
+            .filter(socket -> socket.getSpace().equals(space))
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    public SocketPlace findSocketPlaceBySocketId(Long socketId) {
+        Socket socket = sockets.stream()
+            .filter(s -> s.getId().equals(socketId))
+            .findFirst()
+            .orElseThrow(() -> new ErrorHandler(ErrorStatus.SOCKET_NOT_FOUND)); // Socket이 없을 경우 예외
+
+        Space space = Optional.ofNullable(socket.getSpace())
+            .orElseThrow(() -> new ErrorHandler(ErrorStatus.SPACE_NOT_FOUND)); // Space가 없을 경우 예외
+
+        Floor floor = Optional.ofNullable(space.getFloor())
+            .orElseThrow(() -> new ErrorHandler(ErrorStatus.FLOOR_NOT_FOUND)); // Floor가 없을 경우 예외
+
+        Building building = Optional.ofNullable(floor.getBuilding())
+            .orElseThrow(() -> new ErrorHandler(ErrorStatus.BUILDING_NOT_FOUND)); // Building이 없을 경우 예외
+
+        // 모든 데이터가 유효한 경우 DTO 생성
+        return SocketPlace.builder()
+            .buildingId(building.getId())
+            .level(floor.getLevel())
+            .build();
+    }
+
+
+
+
+
+    @Override
+    public List<Socket> findSocketListByBuildingIdAndLevel(Long buildingId, Integer level) {
+        return buildings.stream()
+            .filter(building -> building.getId().equals(buildingId))
+            .flatMap(building -> floors.stream()
+                .filter(floor -> floor.getBuilding().equals(building) && floor.getLevel().equals(level))
+                .flatMap(floor -> spaces.stream()
+                    .filter(space -> space.getFloor().equals(floor))
+                    .flatMap(space -> sockets.stream()
+                        .filter(socket -> socket.getSpace().equals(space))
+                    )
+                )
+            )
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    public Socket save(Socket socket) {
+        // 중복 데이터 제거
+        sockets.removeIf(existingSocket -> existingSocket.getId().equals(socket.getId()));
+        sockets.add(socket);
+
+        // 관련 데이터 추가
+        if (socket.getSpace() != null) {
+            spaces.removeIf(existingSpace -> existingSpace.getId().equals(socket.getSpace().getId()));
+            spaces.add(socket.getSpace());
+            if (socket.getSpace().getFloor() != null) {
+                floors.removeIf(existingFloor -> existingFloor.getId().equals(socket.getSpace().getFloor().getId()));
+                floors.add(socket.getSpace().getFloor());
+                if (socket.getSpace().getFloor().getBuilding() != null) {
+                    buildings.removeIf(existingBuilding -> existingBuilding.getId().equals(socket.getSpace().getFloor().getBuilding().getId()));
+                    buildings.add(socket.getSpace().getFloor().getBuilding());
+                }
+            }
+        }
+
+        return socket;
+    }
+
+
+
+
+
+    @Override
+    public List<Socket> findAll() {
+        return sockets;
+    }
+
+    @Override
+    public <S extends Socket> List<S> findAll(Example<S> example) {
+        return List.of();
+    }
+
+    @Override
+    public void flush() {
+
+    }
+
+    @Override
+    public <S extends Socket> S saveAndFlush(S entity) {
+        return null;
+    }
+
+    @Override
+    public <S extends Socket> List<S> saveAllAndFlush(Iterable<S> entities) {
+        return List.of();
+    }
+
+    @Override
+    public void deleteAllInBatch(Iterable<Socket> entities) {
+
+    }
+
+    @Override
+    public void deleteAllByIdInBatch(Iterable<Long> longs) {
+
+    }
+
+    @Override
+    public void deleteAllInBatch() {
+
+    }
+
+    @Override
+    public Socket getOne(Long aLong) {
+        return null;
+    }
+
+    @Override
+    public Socket getById(Long aLong) {
+        return null;
+    }
+
+    @Override
+    public Socket getReferenceById(Long aLong) {
+        return null;
+    }
+
+    @Override
+    public <S extends Socket> Optional<S> findOne(Example<S> example) {
+        return Optional.empty();
+    }
+
+    @Override
+    public <S extends Socket> List<S> findAll(Example<S> example, Sort sort) {
+        return List.of();
+    }
+
+    @Override
+    public <S extends Socket> Page<S> findAll(Example<S> example, Pageable pageable) {
+        return null;
+    }
+
+    @Override
+    public <S extends Socket> long count(Example<S> example) {
+        return 0;
+    }
+
+    @Override
+    public <S extends Socket> boolean exists(Example<S> example) {
+        return false;
+    }
+
+    @Override
+    public <S extends Socket, R> R findBy(Example<S> example,
+        Function<FetchableFluentQuery<S>, R> queryFunction) {
+        return null;
+    }
+
+    @Override
+    public <S extends Socket> List<S> saveAll(Iterable<S> entities) {
+        return List.of();
+    }
+
+    @Override
+    public Optional<Socket> findById(Long id) {
+        return sockets.stream()
+            .filter(socket -> socket.getId().equals(id))
+            .findFirst();
+    }
+
+    @Override
+    public boolean existsById(Long aLong) {
+        return false;
+    }
+
+    @Override
+    public List<Socket> findAllById(Iterable<Long> longs) {
+        return List.of();
+    }
+
+    @Override
+    public long count() {
+        return 0;
+    }
+
+    @Override
+    public void deleteById(Long aLong) {
+
+    }
+
+    @Override
+    public void delete(Socket entity) {
+
+    }
+
+    @Override
+    public void deleteAllById(Iterable<? extends Long> longs) {
+
+    }
+
+    @Override
+    public void deleteAll(Iterable<? extends Socket> entities) {
+
+    }
+
+    @Override
+    public void deleteAll() {
+
+    }
+
+    @Override
+    public List<Socket> findAll(Sort sort) {
+        return List.of();
+    }
+
+    @Override
+    public Page<Socket> findAll(Pageable pageable) {
+        return null;
+    }
+}

--- a/src/test/java/com/vincent/domain/socket/service/SocketServiceTest.java
+++ b/src/test/java/com/vincent/domain/socket/service/SocketServiceTest.java
@@ -13,6 +13,7 @@ import com.vincent.domain.socket.controller.dto.SocketResponseDto;
 import com.vincent.domain.socket.controller.dto.SocketResponseDto.SocketPlace;
 import com.vincent.domain.socket.entity.Socket;
 import com.vincent.domain.socket.service.data.SocketDataService;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Assertions;
@@ -63,30 +64,25 @@ public class SocketServiceTest {
         //given
         Long buildingId = 1L;
         int level = 2;
-        Building building = Building.builder().id(1L).build();
-        Floor floor = Floor.builder().id(1L).level(2).building(building).build();
-        Space space = Space.builder().id(1L).floor(floor).build();
-        Socket socket = Socket.builder().id(1L).space(space).build();
-        List<Space> spaces = Collections.singletonList(space);
-        List<Socket> sockets = Collections.singletonList(socket);
+
+        Building building = Building.builder().id(buildingId).build();
+        Floor floor = Floor.builder().id(1L).level(level).building(building).build();
+        Space space1 = Space.builder().id(1L).floor(floor).build();
+        Space space2 = Space.builder().id(2L).floor(floor).build();
+        Socket socket1 = Socket.builder().id(1L).space(space1).build();
+        Socket socket2 = Socket.builder().id(2L).space(space2).build();
+        List<Socket> expectedSockets = Arrays.asList(socket1, socket2);
 
         //when
-        when(buildingDataService.findById(buildingId)).thenReturn(building);
-        when(floorDataService.findByBuildingAndLevel(building, level)).thenReturn(floor);
-        when(spaceDataService.findAllByFloor(floor)).thenReturn(spaces);
-        when(socketDataService.findAllBySpace(space)).thenReturn(sockets);
+        when(socketDataService.findSocketListByBuildingIdAndLevel(
+            buildingId, level)).thenReturn(expectedSockets);
 
         //then
         List<Socket> result = socketService.getSocketList(buildingId, level);
 
         Assertions.assertNotNull(result);
         Assertions.assertFalse(result.isEmpty());
-        Assertions.assertEquals(1, result.size());
-        Assertions.assertEquals(socket, result.get(0));
-        verify(buildingDataService).findById(buildingId);
-        verify(floorDataService).findByBuildingAndLevel(building, level);
-        verify(spaceDataService).findAllByFloor(floor);
-        verify(socketDataService).findAllBySpace(space);
+        Assertions.assertEquals(expectedSockets, result);
     }
 
     @Test

--- a/src/test/java/com/vincent/domain/socket/service/SocketServiceTest.java
+++ b/src/test/java/com/vincent/domain/socket/service/SocketServiceTest.java
@@ -27,15 +27,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 public class SocketServiceTest {
 
     @Mock
-    private FloorDataService floorDataService;
-
-    @Mock
-    private SpaceDataService spaceDataService;
-
-    @Mock
-    private BuildingDataService buildingDataService;
-
-    @Mock
     private SocketDataService socketDataService;
 
     @InjectMocks

--- a/src/test/java/com/vincent/domain/socket/service/data/SocketDataServiceTest.java
+++ b/src/test/java/com/vincent/domain/socket/service/data/SocketDataServiceTest.java
@@ -5,7 +5,15 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.vincent.apipayload.status.ErrorStatus;
+import com.vincent.domain.building.TestBuildingRepository;
+import com.vincent.domain.building.TestFloorRepository;
+import com.vincent.domain.building.TestSpaceRepository;
+import com.vincent.domain.building.entity.Building;
+import com.vincent.domain.building.entity.Floor;
 import com.vincent.domain.building.entity.Space;
+import com.vincent.domain.building.repository.BuildingRepository;
+import com.vincent.domain.building.service.data.BuildingDataService;
+import com.vincent.domain.socket.TestSocketRepository;
 import com.vincent.domain.socket.controller.dto.SocketResponseDto;
 import com.vincent.domain.socket.controller.dto.SocketResponseDto.SocketPlace;
 import com.vincent.domain.socket.entity.Socket;
@@ -15,127 +23,171 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
 class SocketDataServiceTest {
-    @Mock
-    private SocketRepository socketRepository;
 
-    @InjectMocks
+
+
+    private SocketRepository socketRepository;
     private SocketDataService socketDataService;
 
-    @Test
-    void 아아디로_소켓찾기_성공() {
-        //given
-        Long socketId = 1L;
-        Socket socket = Socket.builder().id(1L).build();
 
-        //when
-        when(socketRepository.findById(socketId)).thenReturn(Optional.of(socket));
-
-        //then
-        Socket result = socketDataService.findById(socketId);
-        Assertions.assertEquals(result,socket);
-        verify(socketRepository, times(1)).findById(socketId);
+    @BeforeEach
+    void setUp() {
+        socketRepository = new TestSocketRepository();
+        socketDataService = new SocketDataService(socketRepository);
     }
 
     @Test
-    void 아아디로_소켓찾기_실패() {
-        //given
+    void 저장() {
+        // given
+        Socket socket = Socket.builder().id(1L).build();
+
+        // when
+        Socket result = socketDataService.save(socket);
+
+        // then
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(result, socket);
+        Assertions.assertEquals(1, socketRepository.findAll().size()); // 저장된 데이터 확인
+    }
+
+    @Test
+    void 아이디로_소켓찾기_성공() {
+        // given
         Long socketId = 1L;
+        Socket socket = Socket.builder().id(socketId).build();
+        socketRepository.save(socket);
 
-        //when
-        when(socketRepository.findById(socketId)).thenReturn(Optional.empty());
+        // when
+        Socket result = socketDataService.findById(socketId);
 
-        //then
+        // then
+        Assertions.assertEquals(result, socket);
+    }
+
+    @Test
+    void 아이디로_소켓찾기_실패() {
+        // given
+        Long invalidSocketId = 9L;
+
+        // when & then
         ErrorHandler thrown = Assertions.assertThrows(ErrorHandler.class,
-            () -> socketDataService.findById(socketId));
+            () -> socketDataService.findById(invalidSocketId));
         Assertions.assertEquals(thrown.getCode(), ErrorStatus.SOCKET_NOT_FOUND);
     }
 
     @Test
     void 공간으로_소켓_찾기() {
-        //given
+        // given
         Space space = Space.builder().id(1L).build();
         Socket socket1 = Socket.builder().id(1L).space(space).build();
         Socket socket2 = Socket.builder().id(2L).space(space).build();
-        List<Socket> sockets = Arrays.asList(socket1, socket2);
+        socketRepository.save(socket1);
+        socketRepository.save(socket2);
 
-        //when
-        when(socketRepository.findAllBySpace(space)).thenReturn(sockets);
-
-        //then
+        // when
         List<Socket> result = socketDataService.findAllBySpace(space);
-        Assertions.assertEquals(result.size(), sockets.size());
-        Assertions.assertIterableEquals(result, sockets);
-        verify(socketRepository, times(1)).findAllBySpace(space);
-    }
 
-
-    @Test
-    void 저장() {
-        //given
-        Socket socket = Socket.builder().id(1L).build();
-
-        //when
-        when(socketRepository.save(socket)).thenReturn(socket);
-
-        //then
-        Socket result = socketDataService.save(socket);
-        Assertions.assertNotNull(result);
-        verify(socketRepository).save(socket);
+        // then
+        Assertions.assertEquals(2, result.size());
+        Assertions.assertTrue(result.contains(socket1));
+        Assertions.assertTrue(result.contains(socket2));
     }
 
     @Test
     void 소켓아이디로_빌딩아이디와_층_찾기_성공() {
-        //given
+        // given
         Long socketId = 1L;
-        Socket socket = Socket.builder().id(1L).build();
-        SocketResponseDto.SocketPlace socketPlace;
-        socketPlace = SocketPlace.builder().buildingId(1L).level(1).build();
+        Building building = Building.builder().id(1L).build();
+        Floor floor = Floor.builder().id(1L).level(1).building(building).build();
+        Space space = Space.builder().id(1L).floor(floor).build();
+        Socket socket = Socket.builder().id(socketId).space(space).build();
+        socketRepository.save(socket);
 
-        //when
-        when(socketRepository.findById(socketId)).thenReturn(Optional.of(socket));
-        when(socketRepository.findSocketPlaceBySocketId(socketId)).thenReturn(socketPlace);
-
-        //then
+        // when
         SocketPlace result = socketDataService.findSocketPlaceBySocketId(socketId);
-        Assertions.assertEquals(result.getBuildingId(), socketPlace.getBuildingId());
-        Assertions.assertEquals(result.getLevel(), socketPlace.getLevel());
 
-        //verify
-        verify(socketRepository, times(1)).findById(socketId);
-        verify(socketRepository, times(1)).findSocketPlaceBySocketId(socketId);
-
-
-
+        // then
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals(building.getId(), result.getBuildingId());
+        Assertions.assertEquals(floor.getLevel(), result.getLevel());
     }
 
     @Test
-    void 소켓아이디로_빌딩아이디와_층_찾기_실패() {
-
+    void 소켓아이디로_빌딩아이디와_층_찾기_실패_소켓없음() {
         // given
         Long invalidSocketId = 9L;
 
-        //when
-        when(socketRepository.findById(invalidSocketId)).thenReturn(Optional.empty());
-
-        //then
+        // when & then
         ErrorHandler thrown = Assertions.assertThrows(ErrorHandler.class,
             () -> socketDataService.findById(invalidSocketId));
         Assertions.assertEquals(thrown.getCode(), ErrorStatus.SOCKET_NOT_FOUND);
-
-        //verify
-        verify(socketRepository, times(1)).findById(invalidSocketId);
-        verify(socketRepository, never()).findSocketPlaceBySocketId(invalidSocketId);
-
-
-
     }
+
+    @Test
+    void 소켓아이디로_빌딩아이디와_층_찾기_실패_공간없음() {
+        // given
+        Long socketId = 1L;
+        Socket socket = Socket.builder().id(socketId).space(null).build(); // Space가 없음
+        socketRepository.save(socket);
+
+        // when & then
+        ErrorHandler thrown = Assertions.assertThrows(ErrorHandler.class,
+            () -> socketDataService.findSocketPlaceBySocketId(socketId));
+
+        Assertions.assertEquals(ErrorStatus.SPACE_NOT_FOUND, thrown.getCode());
+    }
+
+    @Test
+    void 소켓아이디로_빌딩아이디와_층_찾기_실패_층없음() {
+        // given
+        Long socketId = 1L;
+        Space space = Space.builder().id(1L).floor(null).build(); // Floor가 없음
+        Socket socket = Socket.builder().id(socketId).space(space).build();
+        socketRepository.save(socket);
+
+        // when & then
+        ErrorHandler thrown = Assertions.assertThrows(ErrorHandler.class,
+            () -> socketDataService.findSocketPlaceBySocketId(socketId));
+
+        Assertions.assertEquals(ErrorStatus.FLOOR_NOT_FOUND, thrown.getCode());
+    }
+
+    @Test
+    void 빌딩아이디와_층으로_소켓목록_찾기_성공() {
+        // given
+        Long buildingId = 1L;
+        Integer level = 2;
+
+        // 관계 설정
+        Building building = Building.builder().id(buildingId).build();
+        Floor floor = Floor.builder().id(1L).level(level).building(building).build();
+        Space space1 = Space.builder().id(1L).floor(floor).build();
+        Space space2 = Space.builder().id(2L).floor(floor).build();
+        Socket socket1 = Socket.builder().id(1L).space(space1).build();
+        Socket socket2 = Socket.builder().id(2L).space(space2).build();
+
+        // 관련 데이터 명시적으로 저장
+        socketRepository.save(socket1);        // Socket1 저장
+        socketRepository.save(socket2);        // Socket2 저장
+
+        // when
+        List<Socket> result = socketDataService.findSocketListByBuildingIdAndLevel(buildingId, level);
+
+        // then
+        Assertions.assertNotNull(result); // 결과가 null이 아닌지 확인
+        Assertions.assertEquals(2, result.size()); // 기대하는 소켓 개수 확인
+        Assertions.assertTrue(result.contains(socket1)); // socket1 포함 여부 확인
+        Assertions.assertTrue(result.contains(socket2)); // socket2 포함 여부 확인
+    }
+
+
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #176  

## 📝작업 내용

## 1. 층 콘센트 조회 api 쿼리 성능 개선

### 기존 로직

- **데이터베이스 호출 횟수**
    - `buildingDataService.findById(buildingId)` → 1번 호출
    - `floorDataService.findByBuildingAndLevel(building, level)` → 1번 호출
    - `spaceDataService.findAllByFloor(floor)` → 1번 호출
    - 각 `space`에 대해 `socketDataService.findAllBySpace(space)` 호출 → **`space` 개수만큼 반복 호출**
    - 총 데이터베이스 호출 횟수는 **N+3번** (N: `space`의 개수).
- **단점**
    - **N+1 문제 발생**: `space` 개수만큼 추가로 데이터베이스 쿼리가 발생. -> 조회 속도 느림
    - 데이터베이스 호출 횟수가 많아질수록 조회 속도가 느려짐.

### 수정된 로직

- > building, floor, space, socket을 4중 join하여 파라미터인 buildingId, Level에 해당하는 소켓 리스트만 리턴하도록 함
- **데이터베이스 호출 횟수**
    - JPQL 쿼리가 한 번 호출되며, 단일 쿼리로 모든 데이터를 가져옴.
    - 총 데이터베이스 호출 횟수는 **1번**.
    - 
- **장점**
    - 단일 쿼리로 필요한 데이터를 모두 가져오므로 **N+1 문제 해결**.
    - 데이터베이스가 연관 관계를 따라 데이터를 효율적으로 조회하므로 속도가 더 빠름.


## 2. 소켓 테스트 코드 모킹 제거

### socketRepositoryTest

- findAllBySpace(Space space)

특정 Space에 연결된 모든 Socket을 반환.
Socket 리스트에서 space와 연결된 Socket을 필터링.

- findSocketPlaceBySocketId(Long socketId)

주어진 socketId로 Socket을 찾고, 해당 Building, Floor, Space 정보를 반환하는 DTO(SocketPlace)를 생성.
Socket, Space, Floor, Building 중 하나라도 없을 경우 예외(ErrorHandler)를 던짐.

- findSocketListByBuildingIdAndLevel(Long buildingId, Integer level)

주어진 Building ID와 Floor Level에 해당하는 모든 Socket 리스트를 반환.
데이터의 계층 구조를 활용해 필터링:
Building → Floor → Space → Socket.

- save(Socket socket)

Socket 객체를 저장하고, 연관된 Space, Floor, Building 객체도 함께 관리.
기존 데이터와 중복되지 않도록 동일한 ID를 가진 객체는 제거 후 새로 추가.