### PR TITLE
:hammer: [FIx/188] 주변 건물 조회 범위 변수 확대

### DIFF
--- a/src/main/java/com/vincent/domain/building/service/data/BuildingDataService.java
+++ b/src/main/java/com/vincent/domain/building/service/data/BuildingDataService.java
@@ -26,8 +26,8 @@ public class BuildingDataService {
     }
 
     public List<Building> findAllByLocation(Double longitude, Double latitude) {
-        final double longitudeRange = 0.0007092929741;
-        final double latitudeRange = 0.00146597950179;
+        final double longitudeRange = 0.0010137091125;
+        final double latitudeRange = 0.00221130994643;
 
         double longitudeLower = longitude - longitudeRange;
         double longitudeUpper = longitude + longitudeRange;

--- a/src/test/java/com/vincent/domain/building/service/data/BuildingDataServiceTest.java
+++ b/src/test/java/com/vincent/domain/building/service/data/BuildingDataServiceTest.java
@@ -78,8 +78,8 @@ class BuildingDataServiceTest {
         // given
         Building building = Building.builder().id(1L).build();
         List<Building> buildingList = Arrays.asList(building);
-        double longitudeRange = 0.0007092929741;
-        double latitudeRange = 0.00146597950179;
+        double longitudeRange = 0.0010137091125;
+        double latitudeRange = 0.00221130994643;
         double longitudeLower = LONGITUDE - longitudeRange;
         double longitudeUpper = LONGITUDE + longitudeRange;
         double latitudeLower = LATITUDE - latitudeRange;


### PR DESCRIPTION
## #️⃣연관된 이슈
> #188

## 📝작업 내용
숭실융합연구원(위도 : 37.496560236205376, 경도 : 126.95609432415551)을 중심으로

<맨 위> 
주소(Address) : 서울 동작구 상도동 산 49-36
위도(Latitude) : 37.4987715461518 / 경도(Longitude) : 126.956743703345

<맨 왼쪽>
주소(Address) : 서울 동작구 상도로55길 16
위도(Latitude) : 37.4972940859693 / 경도(Longitude) : 126.955080615043

![image](https://github.com/user-attachments/assets/ac3d84fc-10af-4544-a5fe-4077b219e394)


위도 차이 = 0.00221130994643
경도 차이 = 0.0010137091125
를 도출하여 범위 변수를 수정했습니다