### PR TITLE
[Hotfix/204] 콘센트 사용 여부 변경 api의 HTTP 메서드 매핑 어노테이션 변경

### DIFF
--- a/src/main/java/com/vincent/domain/iot/controller/IotController.java
+++ b/src/main/java/com/vincent/domain/iot/controller/IotController.java
@@ -9,6 +9,7 @@ import com.vincent.domain.iot.controller.dto.IotResponseDto.IotDataTest;
 import com.vincent.domain.iot.service.IotService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -31,8 +32,9 @@ public class IotController {
         return ApiResponse.onSuccess(null);
     }
 
-    @Operation(summary = "콘센트 사용 여부 변경 하기", description = "IOT 장치가 보낸 사용 여부 정보로 콘센트 사용 여부를 변경함")
-    @PatchMapping("/iot/{deviceId}")
+    @Operation(summary = "Iot가 전송하는 데이터 조회하기",
+        description = "기존의 콘센트 사용 여부 변경 api에서 로직을 제외한 버전으로, Iot의 데이터 전송이 잘 되는지만 확인하는 용도")
+    @GetMapping("/iot/{deviceId}")
     public ApiResponse<IotResponseDto.IotDataTest> updateIsSocketUsing(
         @PathVariable("deviceId") Long deviceId,
         @RequestParam("isUsing") int isUsing) {


### PR DESCRIPTION
## #️⃣연관된 이슈
> #204 

## 📝작업 내용
> 원래 만들려고 했던 api : 콘센트 사용 여부 변경 api
   완성하지 못한 이유 : 로직이 확정이 안 됨
   대안책 :  일단 빠른 개발을 위해, Iot가 보내는 값을 잘 리턴하는 지만을 확인하는 간단한 방식의 api로 변경(Fix/203)
   Hotfix/204로 코드 수정한 이유 : 기존의 api는 Patch 요청이지만 대안책 api는 get 요청임. 그러나 Fix/203 으로 대안책 api를 push를 했을 때, 이 HTTP 메서드 매핑 어노테이션을 변경을 안 함. 따라서 이 어노테이션을 수정하여 Hotfix/204로 다시 push를 하였음.
   
