### PR TITLE
:hammer: iot가 전달한 값에 따라 1 -> 사용중, 0 -> 10분 후 사용 없음으로 변경하는 로직

### DIFF
--- a/src/main/java/com/vincent/config/redis/service/RedisKeyExpirationListener.java
+++ b/src/main/java/com/vincent/config/redis/service/RedisKeyExpirationListener.java
@@ -21,15 +21,16 @@ public class RedisKeyExpirationListener extends KeyExpirationEventMessageListene
 
     @Override
     public void onMessage(Message message, byte[] pattern) {
-        String expiredKey = message.toString(); // 만료된 키 가져오기
+        String expiredKey = message.toString();
         handleExpiredKey(expiredKey);
-        log.info("{}상태 변경", expiredKey);
+        log.info("만료된 키: {}", expiredKey);
     }
 
     private void handleExpiredKey(String key) {
-        // 키에서 deviceId 추출
-        Long deviceId = Long.parseLong(key.split(":")[1]);
-        iotService.updateIsSocketUsing(deviceId);
+        if (key.startsWith("iot:")) {
+            Long deviceId = Long.parseLong(key.split(":")[1]);
+            iotService.updateSocketStatus(deviceId, 0); // 만료된 경우 콘센트 상태 비활성화
+        }
     }
 
 }

--- a/src/main/java/com/vincent/config/redis/service/RedisKeyExpirationListener.java
+++ b/src/main/java/com/vincent/config/redis/service/RedisKeyExpirationListener.java
@@ -29,7 +29,7 @@ public class RedisKeyExpirationListener extends KeyExpirationEventMessageListene
     private void handleExpiredKey(String key) {
         if (key.startsWith("iot:")) {
             Long deviceId = Long.parseLong(key.split(":")[1]);
-            iotService.updateSocketStatus(deviceId, 0); // 만료된 경우 콘센트 상태 비활성화
+            iotService.updateSocketIsUsing(deviceId); // 만료된 경우 콘센트 상태 비활성화
         }
     }
 

--- a/src/main/java/com/vincent/config/redis/service/RedisService.java
+++ b/src/main/java/com/vincent/config/redis/service/RedisService.java
@@ -160,6 +160,29 @@ public class RedisService {
         setExpire(redisKey, TTL); // TTL 설정
     }
 
+    /**
+     * IoT 데이터를 기반으로 Redis에 상태 저장 및 TTL 갱신
+     */
+    public void updateDeviceStatus(Long deviceId, int motionStatus) {
+        String redisKey = "iot:" + deviceId;
+
+        if (motionStatus == 1) {
+            // 움직임 있음: TTL 연장
+            redisTemplate.opsForValue().set(redisKey, "active", TTL.toSeconds(), TimeUnit.SECONDS);
+        } else if (motionStatus == 0) {
+            // 움직임 없음: 상태만 저장하고 TTL 유지
+            redisTemplate.opsForValue().set(redisKey, "inactive");
+            redisTemplate.expire(redisKey, TTL);
+        }
+    }
+
+    /**
+     * Redis TTL 만료 여부 확인
+     */
+    public boolean isTTLExpired(String redisKey) {
+        return redisTemplate.opsForValue().get(redisKey) == null;
+    }
+
 
 
 }

--- a/src/main/java/com/vincent/config/redis/service/RedisService.java
+++ b/src/main/java/com/vincent/config/redis/service/RedisService.java
@@ -172,7 +172,6 @@ public class RedisService {
         } else if (motionStatus == 0) {
             // 움직임 없음: 상태만 저장하고 TTL 유지
             redisTemplate.opsForValue().set(redisKey, "inactive");
-            redisTemplate.expire(redisKey, TTL);
         }
     }
 

--- a/src/main/java/com/vincent/config/security/SecurityConfig.java
+++ b/src/main/java/com/vincent/config/security/SecurityConfig.java
@@ -70,7 +70,7 @@ public class SecurityConfig {
                 .authenticationEntryPoint(jwtAuthenticationEntryPoint)
                 .accessDeniedHandler(jwtAccessDeniedHandler))
             .authorizeHttpRequests((request) -> request
-                .requestMatchers("/v1/login", "/v1/reissue").permitAll()
+                .requestMatchers("/v1/login", "/v1/reissue","/v1/iot", "/v1/iot/**").permitAll()
                 .requestMatchers("/actuator/**").permitAll()
                 .anyRequest().authenticated())
             .addFilterBefore(new JwtFilter(jwtProvider),

--- a/src/main/java/com/vincent/domain/iot/controller/IotController.java
+++ b/src/main/java/com/vincent/domain/iot/controller/IotController.java
@@ -31,12 +31,13 @@ public class IotController {
         return ApiResponse.onSuccess(null);
     }
 
-    @Operation(summary = "콘센트 사용 여부 변경 하기", description = "IOT 장치가 보낸 사용 여부 정보로 콘센트 사용 여부를 변경함")
+    @Operation(summary = "콘센트 사용 여부 변경", description = "IoT 장치로부터 움직임 여부 값을 받아 콘센트 사용 여부를 변경합니다.")
     @PatchMapping("/iot/{deviceId}")
-    public ApiResponse<IotResponseDto.IotDataTest> updateIsSocketUsing(
+    public ApiResponse<?> updateSocketStatus(
         @PathVariable("deviceId") Long deviceId,
-        @RequestParam("isUsing") int isUsing) {
-        boolean isUpdated = iotService.setSocketUsage(deviceId, isUsing);
-        return ApiResponse.onSuccess(IotConverter.toIotDataTest(deviceId, isUpdated));
+        @RequestParam("motionStatus") int motionStatus) {
+        iotService.updateSocketStatus(deviceId, motionStatus);
+        return ApiResponse.onSuccess(null);
     }
+
 }

--- a/src/main/java/com/vincent/domain/iot/entity/Iot.java
+++ b/src/main/java/com/vincent/domain/iot/entity/Iot.java
@@ -1,18 +1,14 @@
 package com.vincent.domain.iot.entity;
 
+import com.vincent.domain.iot.entity.enums.MotionStatus;
 import com.vincent.domain.socket.entity.Socket;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 
 @Entity
 @Getter
@@ -29,7 +25,15 @@ public class Iot {
     @Column(unique = true, nullable = false)
     private Long deviceId;
 
+    @Enumerated(EnumType.STRING)
+    @ColumnDefault("'INACTIVE'")
+    private MotionStatus motionStatus;
+
     @OneToOne
     @JoinColumn(name = "socket_id", nullable = false)
     private Socket socket;
+
+    public void updateMotionStatus(MotionStatus motionStatus) {
+        this.motionStatus = motionStatus;
+    }
 }

--- a/src/main/java/com/vincent/domain/iot/entity/enums/MotionStatus.java
+++ b/src/main/java/com/vincent/domain/iot/entity/enums/MotionStatus.java
@@ -1,0 +1,5 @@
+package com.vincent.domain.iot.entity.enums;
+
+public enum MotionStatus {
+    ACTIVE, INACTIVE
+}

--- a/src/test/java/com/vincent/config/redis/service/RedisServiceTest.java
+++ b/src/test/java/com/vincent/config/redis/service/RedisServiceTest.java
@@ -258,7 +258,7 @@ class RedisServiceTest {
         List<Object> result = redisService.getList(key, 0, -1);
 
         // Then
-        Assertions.assertEquals(expectedList, result);
+        assertEquals(expectedList, result);
     }
 
     @Test
@@ -310,7 +310,7 @@ class RedisServiceTest {
         boolean exists = redisService.hasKey(key);
 
         // Then
-        Assertions.assertTrue(exists);
+        assertTrue(exists);
         verify(redisTemplate, times(1)).hasKey(key);
     }
 

--- a/src/test/java/com/vincent/domain/iot/service/IotServiceTest.java
+++ b/src/test/java/com/vincent/domain/iot/service/IotServiceTest.java
@@ -12,16 +12,21 @@ import com.vincent.domain.socket.repository.SocketRepository;
 import com.vincent.domain.socket.service.data.SocketDataService;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.mockito.Mockito.*;
 import static org.junit.jupiter.api.Assertions.*;
-
 
 
 class IotServiceTest {
@@ -71,129 +76,85 @@ class IotServiceTest {
     }
 
     @Test
-    void IoT_장치_값_저장_Redis에_값이_없음() {
-        //given
+    void IoT_상태_업데이트_움직임_있을때() {
+        // given
         Long deviceId = 1L;
-        int isUsing = 1;
-        String redisKey = "iot:"+deviceId;
+        int motionStatus = 1;  // 움직임 있음
+        String redisKey = "iot:" + deviceId;
         Socket socket = Socket.builder().id(1L).name("name").isUsing(false).build();
         Iot iot = Iot.builder().deviceId(deviceId).socket(socket).build();
 
-        //when
-        when(redisService.hasKey(redisKey)).thenReturn(false);
+        // Mocking
         when(iotDataService.findByDeviceId(deviceId)).thenReturn(iot);
-        boolean result = iotService.setSocketUsage(deviceId, isUsing);
+        when(redisService.isTTLExpired(redisKey)).thenReturn(true);
 
-        //then
-        Assertions.assertTrue(result);
+        // when
+        iotService.updateSocketStatus(deviceId, motionStatus);
+
+        // then
+        Assertions.assertTrue(iot.getSocket().getIsUsing());
+
+        verify(redisService, times(1)).updateDeviceStatus(deviceId, motionStatus);
+        verify(iotDataService, times(1)).findByDeviceId(deviceId);
     }
 
+
     @Test
-    void IoT_장치_값_저장_Redis에_값이_있음() {
-        //given
+    void IoT_상태_업데이트_움직임_없을때() throws InterruptedException {
+        // given
         Long deviceId = 1L;
-        int isUsing = 1;
-        String redisKey = "iot:"+deviceId;
-        Socket socket = Socket.builder().id(1L).name("name").isUsing(false).build();
+        int motionStatus = 0;  // 움직임 없음
+        String redisKey = "iot:" + deviceId;
+        Socket socket = Socket.builder().id(1L).name("name").isUsing(true).build();
         Iot iot = Iot.builder().deviceId(deviceId).socket(socket).build();
 
-        //when
-        when(redisService.hasKey(redisKey)).thenReturn(true);
-        when(iotDataService.findByDeviceId(deviceId)).thenReturn(iot);
-        boolean result = iotService.setSocketUsage(deviceId, isUsing);
+        // 비동기 작업을 위한 스케줄러 모킹
+        doAnswer(invocation -> {
+            // 상태 업데이트가 이루어졌을 때 socket 상태 변경
+            iot.getSocket().setIsUsing(false);
+            return null;
+        }).when(iotService).updateSocketIsUsing(iot, false);  // updateSocketIsUsing 메서드 모킹
 
-        //then
-        Assertions.assertTrue(result);
+        // when
+        when(redisService.isTTLExpired(redisKey)).thenReturn(true);
+        when(iotDataService.findByDeviceId(deviceId)).thenReturn(iot);
+
+        iotService.updateSocketStatus(deviceId, motionStatus);
+
+        // then
+        assertFalse(iot.getSocket().getIsUsing());  // 상태가 'false'로 변경되었는지 확인
     }
 
+
+
+
     @Test
-    void 소켓_사용여부_업데이트() {
-        //given
+    void 소켓_상태_변경_성공() {
+        // given
         Long deviceId = 1L;
         Socket socket = Socket.builder().id(1L).name("name").isUsing(false).build();
         Iot iot = Iot.builder().deviceId(deviceId).socket(socket).build();
 
-        //when
+        // when
         when(iotDataService.findByDeviceId(deviceId)).thenReturn(iot);
-        iotService.updateIsSocketUsing(deviceId);
+        iotService.updateSocketIsUsing(iot, true);
 
-        //then
+        // then
         Assertions.assertTrue(iot.getSocket().getIsUsing());
     }
 
-//    @Test
-//    void 소켓_사용여부_업데이트_성공() {
-//        // given
-//        Long deviceId = 1L;
-//        String redisKey = "iot:" + deviceId;
-//
-//        // Redis 데이터 추가 (40개 0, 60개 1)
-//        List<Object> redisData = new ArrayList<>();
-//        for (int i = 0; i < 40; i++) redisData.add("0");
-//        for (int i = 0; i < 60; i++) redisData.add("1");
-//        when(redisService.getList(redisKey, 0, -1)).thenReturn(redisData);
-//
-//        // Mock된 Socket 및 Iot 생성
-//        Socket socket = Socket.builder().id(1L).name("socket1").isUsing(false).build();
-//        Iot iot = Iot.builder().deviceId(deviceId).socket(socket).build();
-//
-//        when(iotDataService.findByDeviceId(deviceId)).thenReturn(iot);
-//        when(socketDataService.findById(socket.getId())).thenReturn(socket);
-//
-//        // when
-//        boolean result = iotService.updateIsSocketUsing(deviceId);
-//
-//        // then
-//        Assertions.assertTrue(result);
-//        verify(redisService, times(1)).getList(redisKey, 0, -1);
-//        verify(redisService, times(1)).delete(redisKey);
-//    }
-//
-//
-//
-//    @Test
-//    void 소켓_사용여부_업데이트_실패_데이터부족() {
-//        // given
-//        Long deviceId = 2L;
-//        String redisKey = "iot:" + deviceId;
-//
-//        when(redisService.getList(redisKey, 0, -1)).thenReturn(new ArrayList<>());
-//
-//        // when
-//        boolean result = iotService.updateIsSocketUsing(deviceId);
-//
-//        // then
-//        assertFalse(result);
-//        verify(redisService, times(1)).getList(redisKey, 0, -1);
-//        verify(redisService, never()).delete(redisKey);
-//    }
-//
-//    @Test
-//    void 소켓_사용여부_업데이트_성공_0이_더많은경우() {
-//        // given
-//        Long deviceId = 3L;
-//        String redisKey = "iot:" + deviceId;
-//
-//        List<Object> redisData = new ArrayList<>();
-//        for (int i = 0; i < 60; i++) redisData.add("0");
-//        for (int i = 0; i < 40; i++) redisData.add("1");
-//
-//        when(redisService.getList(redisKey, 0, -1)).thenReturn(redisData);
-//
-//        Socket socket = Socket.builder().id(2L).name("socket2").isUsing(true).build();
-//        Iot iot = Iot.builder().deviceId(deviceId).socket(socket).build();
-//
-//        when(iotDataService.findByDeviceId(deviceId)).thenReturn(iot);
-//        when(socketDataService.findById(socket.getId())).thenReturn(socket);
-//
-//        // when
-//        boolean result = iotService.updateIsSocketUsing(deviceId);
-//
-//        // then
-//        assertTrue(result);
-//        assertFalse(socket.getIsUsing());
-//        verify(redisService, times(1)).getList(redisKey, 0, -1);
-//        verify(redisService, times(1)).delete(redisKey);
-//
-//    }
+    @Test
+    void 소켓_상태_변경_실패() {
+        // given
+        Long deviceId = 1L;
+        Socket socket = Socket.builder().id(1L).name("name").isUsing(true).build();
+        Iot iot = Iot.builder().deviceId(deviceId).socket(socket).build();
+
+        // when
+        when(iotDataService.findByDeviceId(deviceId)).thenReturn(iot);
+        iotService.updateSocketIsUsing(iot, true); // 상태가 이미 true이므로 변화 없음
+
+        // then
+        Assertions.assertTrue(iot.getSocket().getIsUsing());  // 상태 변화가 없으므로 여전히 true
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #203 

## 📝작업 내용

### 1. 변수 명확히 재 설정: 
움직임 여부의 변수 명은 motionStatus, 사용 여부의 변수 명은 isUsing으로 각각 재설정

### 2. 스케줄링 사용:

ScheduledExecutorService를 사용해 10분 후에 작업을 실행하도록 설정.
Redis TTL 만료 여부를 확인한 뒤 소켓 상태를 변경.


### 3. 즉시 변경과 지연 변경 분리:

motionStatus == 1인 경우 소켓 상태를 바로 true로 설정.
motionStatus == 0인 경우 10분 후 상태를 false로 변경.


### 4. Redis TTL 만료 확인:

Redis 키의 TTL이 만료되었는지 확인하는 로직을 RedisService에 추가.
