### PR TITLE
:recycle: DDD 원칙 적용하여 IoT 상태 관리 로직 개선

### DIFF
--- a/src/main/java/com/vincent/domain/iot/entity/Iot.java
+++ b/src/main/java/com/vincent/domain/iot/entity/Iot.java
@@ -33,7 +33,18 @@ public class Iot {
     @JoinColumn(name = "socket_id", nullable = false)
     private Socket socket;
 
-    public void updateMotionStatus(MotionStatus motionStatus) {
-        this.motionStatus = motionStatus;
+    public void activate() {
+        this.motionStatus = MotionStatus.ACTIVE;
+        this.socket.setIsUsing(true);
+    }
+
+    public void deactivate() {
+        this.motionStatus = MotionStatus.INACTIVE;
+    }
+
+    public void updateSocketStatus() {
+        if (motionStatus == MotionStatus.INACTIVE) {
+            this.socket.setIsUsing(false);
+        }
     }
 }

--- a/src/main/java/com/vincent/domain/iot/service/IotService.java
+++ b/src/main/java/com/vincent/domain/iot/service/IotService.java
@@ -25,7 +25,6 @@ public class IotService {
     private final IotDataService iotDataService;
     private final SocketDataService socketDataService;
     private final RedisService redisService;
-//    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
 
 
     @Transactional
@@ -44,10 +43,9 @@ public class IotService {
         Iot iot = iotDataService.findByDeviceId(deviceId);
         if (motionStatus == 1) {
             redisService.updateDeviceStatus(deviceId, motionStatus);
-            iot.updateMotionStatus(MotionStatus.ACTIVE);
-            iot.getSocket().setIsUsing(true);
+            iot.activate();
         } else if (motionStatus == 0) {
-            iot.updateMotionStatus(MotionStatus.INACTIVE);
+            iot.deactivate();
         }
     }
 
@@ -57,9 +55,8 @@ public class IotService {
     @Transactional
     public void updateSocketIsUsing(Long deviceId) {
         Iot iot = iotDataService.findByDeviceId(deviceId);
-        if(iot.getMotionStatus().equals(MotionStatus.INACTIVE)){
-            iot.getSocket().setIsUsing(false);
-        } else {
+        iot.updateSocketStatus();
+        if(iot.getMotionStatus().equals(MotionStatus.ACTIVE)){
             redisService.updateDeviceStatus(deviceId, 1);
         }
     }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #211 

## 📝작업 내용
- IoT 엔티티에서 상태 변경을 직접 관리하도록, `activate()`, `deactivate()`, `updateSocketStatus()` 추가
- 서비스 계층에서 도메인 객체의 메서드를 호출하는 방식으로 변경

### 기존 코드
``` java
  iot.updateMotionStatus(MotionStatus.ACTIVE);
  iot.getSocket().setIsUsing(true);
```
### 변경된 코드
``` java
// IotService
iot.activate();

//Iot
public class Iot {
    public void activate() {
        this.motionStatus = MotionStatus.ACTIVE;
        this.socket.setIsUsing(true);
    }
}

```